### PR TITLE
Update the data structures to use Pandas DataFrames

### DIFF
--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -78,7 +78,8 @@ class CatalogManager(object):
             The persisted DataFrameMetadata object with the id field populated.
         """
 
-        metadata = self._dataset_service.create_dataset(name, file_url, identifier_id=identifier_column)
+        metadata = self._dataset_service.create_dataset(name, file_url,
+                                                        identifier_id=identifier_column)
         for column in column_list:
             column.metadata_id = metadata.id
         column_list = self._column_service.create_column(column_list)
@@ -248,3 +249,15 @@ class CatalogManager(object):
             udf_io.udf_id = metadata.id
         self._udf_io_service.add_udf_io(udf_io_list)
         return metadata
+
+    def get_udf_by_name(self, name: str) -> UdfMetadata:
+        """
+        Get the UDF information based on name.
+
+        Arguments:
+             name (str): name of the UDF
+
+        Returns:
+            UdfMetadata object
+        """
+        return self._udf_service.udf_by_name(name)

--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -60,7 +60,8 @@ class CatalogManager(object):
         init_db()
 
     def create_metadata(self, name: str, file_url: str,
-                        column_list: List[DataFrameColumn]) -> \
+                        column_list: List[DataFrameColumn],
+                        identifier_column='id') -> \
             DataFrameMetadata:
         """Creates metadata object when called by create executor.
 
@@ -71,12 +72,13 @@ class CatalogManager(object):
             name: name of the dataset/video to which this metdata corresponds
             file_url: #todo
             column_list: list of columns
+            identifier_column (str):  A unique identifier column for each row
 
         Returns:
             The persisted DataFrameMetadata object with the id field populated.
         """
 
-        metadata = self._dataset_service.create_dataset(name, file_url)
+        metadata = self._dataset_service.create_dataset(name, file_url, identifier_id=identifier_column)
         for column in column_list:
             column.metadata_id = metadata.id
         column_list = self._column_service.create_column(column_list)

--- a/src/catalog/models/df_metadata.py
+++ b/src/catalog/models/df_metadata.py
@@ -24,14 +24,16 @@ class DataFrameMetadata(BaseModel):
 
     _name = Column('name', String(100), unique=True)
     _file_url = Column('file_url', String(100))
+    _unique_identifier_column = Column('identifier_column', String(100))
 
     _columns = relationship('DataFrameColumn',
                             back_populates="_dataset")
 
-    def __init__(self, name: str, file_url: str):
+    def __init__(self, name: str, file_url: str, identifier_id='id'):
         self._name = name
         self._file_url = file_url
         self._schema = None
+        self._unique_identifier_column = identifier_id
 
     @property
     def schema(self):
@@ -56,3 +58,7 @@ class DataFrameMetadata(BaseModel):
     @property
     def columns(self):
         return self._columns
+
+    @property
+    def identifier_column(self):
+        return self._unique_identifier_column

--- a/src/catalog/services/df_service.py
+++ b/src/catalog/services/df_service.py
@@ -25,7 +25,7 @@ class DatasetService(BaseService):
     def __init__(self):
         super().__init__(DataFrameMetadata)
 
-    def create_dataset(self, name, file_url) -> DataFrameMetadata:
+    def create_dataset(self, name, file_url, identifier_id='id') -> DataFrameMetadata:
         """
         Create a new dataset entry for given name and file URL.
         Arguments:
@@ -35,7 +35,7 @@ class DatasetService(BaseService):
         Returns:
             DataFrameMetadata object
         """
-        metadata = self.model(name=name, file_url=file_url)
+        metadata = self.model(name=name, file_url=file_url, identifier_id=identifier_id)
         metadata = metadata.save()
         return metadata
 

--- a/src/executor/create_udf_executor.py
+++ b/src/executor/create_udf_executor.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 
 from src.catalog.catalog_manager import CatalogManager
-from src.planner.create_udf_plan import CreateUDFPlan
 from src.executor.abstract_executor import AbstractExecutor
-import tempfile
-import os.path
+from src.planner.create_udf_plan import CreateUDFPlan
 
 
 class CreateUDFExecutor(AbstractExecutor):

--- a/src/executor/disk_based_storage_executor.py
+++ b/src/executor/disk_based_storage_executor.py
@@ -15,7 +15,7 @@
 from typing import Iterator
 
 from src.loaders import Loader
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.executor.abstract_storage_executor import \
     AbstractStorageExecutor
 from src.planner.storage_plan import StoragePlan
@@ -43,6 +43,6 @@ class DiskStorageExecutor(AbstractStorageExecutor):
     def validate(self):
         pass
 
-    def exec(self) -> Iterator[FrameBatch]:
+    def exec(self) -> Iterator[Batch]:
         for batch in self.storage.load():
             yield batch

--- a/src/executor/plan_executor.py
+++ b/src/executor/plan_executor.py
@@ -16,7 +16,7 @@ import pandas as pd
 
 from src.executor.abstract_executor import AbstractExecutor
 from src.executor.seq_scan_executor import SequentialScanExecutor
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.planner.abstract_plan import AbstractPlan
 from src.planner.types import PlanNodeType
 from src.executor.disk_based_storage_executor import DiskStorageExecutor
@@ -91,7 +91,7 @@ class PlanExecutor:
         # a stitched output
         execution_tree = self._build_execution_tree(self._plan)
 
-        output_batches = FrameBatch(pd.DataFrame())
+        output_batches = Batch(pd.DataFrame())
 
         # ToDo generalize this logic
         _INSERT_CREATE_ = (

--- a/src/executor/plan_executor.py
+++ b/src/executor/plan_executor.py
@@ -12,8 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pandas as pd
+
 from src.executor.abstract_executor import AbstractExecutor
 from src.executor.seq_scan_executor import SequentialScanExecutor
+from src.models.storage.batch import FrameBatch
 from src.planner.abstract_plan import AbstractPlan
 from src.planner.types import PlanNodeType
 from src.executor.disk_based_storage_executor import DiskStorageExecutor
@@ -88,7 +91,7 @@ class PlanExecutor:
         # a stitched output
         execution_tree = self._build_execution_tree(self._plan)
 
-        output_batches = []
+        output_batches = FrameBatch(pd.DataFrame())
 
         # ToDo generalize this logic
         _INSERT_CREATE_ = (
@@ -99,7 +102,7 @@ class PlanExecutor:
             execution_tree.exec()
         else:
             for batch in execution_tree.exec():
-                output_batches.append(batch)
+                output_batches += batch
 
         self._clean_execution_tree(execution_tree)
         return output_batches

--- a/src/executor/pp_executor.py
+++ b/src/executor/pp_executor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Iterator
 
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.executor.abstract_executor import AbstractExecutor
 from src.planner.pp_plan import PPScanPlan
 
@@ -37,7 +37,7 @@ class PPExecutor(AbstractExecutor):
     def validate(self):
         pass
 
-    def exec(self) -> Iterator[FrameBatch]:
+    def exec(self) -> Iterator[Batch]:
         child_executor = self.children[0]
         for batch in child_executor.exec():
             outcomes = self.predicate.evaluate(batch)

--- a/src/executor/seq_scan_executor.py
+++ b/src/executor/seq_scan_executor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from typing import Iterator
 
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.executor.abstract_executor import AbstractExecutor
 from src.planner.seq_scan_plan import SeqScanPlan
 
@@ -34,7 +34,7 @@ class SequentialScanExecutor(AbstractExecutor):
     def validate(self):
         pass
 
-    def exec(self) -> Iterator[FrameBatch]:
+    def exec(self) -> Iterator[Batch]:
 
         child_executor = self.children[0]
         for batch in child_executor.exec():

--- a/src/expression/arithmetic_expression.py
+++ b/src/expression/arithmetic_expression.py
@@ -32,11 +32,11 @@ class ArithmeticExpression(AbstractExpression):
         vl = self.get_child(0).evaluate(*args)
         vr = self.get_child(1).evaluate(*args)
 
-        if (self.etype == ExpressionType.ARITHMETIC_ADD):
+        if self.etype == ExpressionType.ARITHMETIC_ADD:
             return vl + vr
-        elif(self.etype == ExpressionType.ARITHMETIC_SUBTRACT):
+        elif self.etype == ExpressionType.ARITHMETIC_SUBTRACT:
             return vl - vr
-        elif(self.etype == ExpressionType.ARITHMETIC_MULTIPLY):
+        elif self.etype == ExpressionType.ARITHMETIC_MULTIPLY:
             return vl * vr
-        elif(self.etype == ExpressionType.ARITHMETIC_DIVIDE):
+        elif self.etype == ExpressionType.ARITHMETIC_DIVIDE:
             return vl / vr

--- a/src/expression/function_expression.py
+++ b/src/expression/function_expression.py
@@ -17,7 +17,7 @@ from typing import Callable
 
 from src.expression.abstract_expression import AbstractExpression, \
     ExpressionType
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 
 
 @unique
@@ -58,7 +58,7 @@ class FunctionExpression(AbstractExpression):
         self.function = func
         self.is_temp = is_temp
 
-    def evaluate(self, batch: FrameBatch):
+    def evaluate(self, batch: Batch):
         args = []
         if self.get_children_count() > 0:
             child = self.get_child(0)

--- a/src/expression/function_expression.py
+++ b/src/expression/function_expression.py
@@ -70,5 +70,4 @@ class FunctionExpression(AbstractExpression):
 
         if self.mode == ExecutionMode.EXEC:
             batch.set_outcomes(self.name, outcome, is_temp=self.is_temp)
-
         return outcome

--- a/src/expression/tuple_value_expression.py
+++ b/src/expression/tuple_value_expression.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from src.catalog.models.df_column import DataFrameColumn
+from src.models.storage.batch import FrameBatch
 from .abstract_expression import AbstractExpression, ExpressionType, \
     ExpressionReturnType
 
@@ -66,9 +67,9 @@ class TupleValueExpression(AbstractExpression):
         self._col_object = value
 
     # remove this once doen with tuple class
-    def evaluate(self, *args):
+    def evaluate(self, batch: FrameBatch, *args):
         if args is None:
             # error Handling
             pass
-        given_tuple = args[0]
-        return given_tuple[(self._col_idx)]
+
+        return batch.frames_as_numpy_array(self.col_name)

--- a/src/expression/tuple_value_expression.py
+++ b/src/expression/tuple_value_expression.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from src.catalog.models.df_column import DataFrameColumn
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from .abstract_expression import AbstractExpression, ExpressionType, \
     ExpressionReturnType
 
@@ -67,9 +67,9 @@ class TupleValueExpression(AbstractExpression):
         self._col_object = value
 
     # remove this once doen with tuple class
-    def evaluate(self, batch: FrameBatch, *args):
+    def evaluate(self, batch: Batch, *args):
         if args is None:
             # error Handling
             pass
 
-        return batch.frames_as_numpy_array(self.col_name)
+        return batch.column_as_numpy_array(self.col_name)

--- a/src/loaders/abstract_loader.py
+++ b/src/loaders/abstract_loader.py
@@ -66,13 +66,13 @@ class AbstractVideoLoader(metaclass=ABCMeta):
             if self.skip_frames > 0 and record.get(self.identifier_column, 0) % self.skip_frames != 0:
                 continue
             if self.limit and record.get(self.identifier_column, 0) >= self.limit:
-                return FrameBatch(pd.DataFrame(frames))
+                return FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
             frames.append(record)
             if len(frames) % self.batch_size == 0:
-                yield FrameBatch(pd.DataFrame(frames))
+                yield FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
                 frames = []
         if frames:
-            return FrameBatch(pd.DataFrame(frames))
+            return FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
 
     @abstractmethod
     def _load_frames(self) -> Iterator[Dict]:

--- a/src/loaders/abstract_loader.py
+++ b/src/loaders/abstract_loader.py
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABCMeta, abstractmethod
-from typing import Iterator
+from typing import Iterator, Dict
+
+import pandas as pd
 
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.models.storage.batch import FrameBatch
-from src.models.storage.frame import Frame
 
 
 class AbstractVideoLoader(metaclass=ABCMeta):
@@ -48,6 +49,7 @@ class AbstractVideoLoader(metaclass=ABCMeta):
         self.limit = limit
         self.curr_shard = curr_shard
         self.total_shards = total_shards
+        self.identifier_column = video_metadata.identifier_column if video_metadata.identifier_column else 'id'
 
     def load(self) -> Iterator[FrameBatch]:
         """
@@ -56,27 +58,28 @@ class AbstractVideoLoader(metaclass=ABCMeta):
 
         Yields:
         :obj: `eva.models.FrameBatch`: An object containing a batch of frames
-                                       and frame specific metadata
+                                       and record specific metadata
         """
 
         frames = []
-        for frame in self._load_frames():
-            if self.skip_frames > 0 and frame.index % self.skip_frames != 0:
+        for record in self._load_frames():
+            if self.skip_frames > 0 and record.get(self.identifier_column, 0) % self.skip_frames != 0:
                 continue
-            if self.limit and frame.index >= self.limit:
-                return FrameBatch(frames, frame.info)
-            frames.append(frame)
+            if self.limit and record.get(self.identifier_column, 0) >= self.limit:
+                return FrameBatch(pd.DataFrame(frames))
+            frames.append(record)
             if len(frames) % self.batch_size == 0:
-                yield FrameBatch(frames, frame.info)
+                yield FrameBatch(pd.DataFrame(frames))
                 frames = []
         if frames:
-            return FrameBatch(frames, frames[0].info)
+            return FrameBatch(pd.DataFrame(frames))
 
     @abstractmethod
-    def _load_frames(self) -> Iterator[Frame]:
+    def _load_frames(self) -> Iterator[Dict]:
         """
         Loads video frames from storage and returns the Frame type.
 
         Yields:
             Frame:  A frame object of the video, used for processing.
         """
+        pass

--- a/src/loaders/abstract_loader.py
+++ b/src/loaders/abstract_loader.py
@@ -57,22 +57,27 @@ class AbstractVideoLoader(metaclass=ABCMeta):
          Uses the video metadata and other class arguments
 
         Yields:
-        :obj: `eva.models.FrameBatch`: An object containing a batch of frames
+        :obj: `Batch`: An object containing a batch of frames
                                        and record specific metadata
         """
 
         frames = []
         for record in self._load_frames():
-            if self.skip_frames > 0 and record.get(self.identifier_column, 0) % self.skip_frames != 0:
+            if self.skip_frames > 0 and record.get(self.identifier_column,
+                                                   0) % self.skip_frames != 0:
                 continue
-            if self.limit and record.get(self.identifier_column, 0) >= self.limit:
-                return Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+            if self.limit and record.get(self.identifier_column,
+                                         0) >= self.limit:
+                return Batch(pd.DataFrame(frames),
+                             identifier_column=self.identifier_column)
             frames.append(record)
             if len(frames) % self.batch_size == 0:
-                yield Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+                yield Batch(pd.DataFrame(frames),
+                            identifier_column=self.identifier_column)
                 frames = []
         if frames:
-            return Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+            return Batch(pd.DataFrame(frames),
+                         identifier_column=self.identifier_column)
 
     @abstractmethod
     def _load_frames(self) -> Iterator[Dict]:

--- a/src/loaders/abstract_loader.py
+++ b/src/loaders/abstract_loader.py
@@ -18,7 +18,7 @@ from typing import Iterator, Dict
 import pandas as pd
 
 from src.catalog.models.df_metadata import DataFrameMetadata
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 
 
 class AbstractVideoLoader(metaclass=ABCMeta):
@@ -51,7 +51,7 @@ class AbstractVideoLoader(metaclass=ABCMeta):
         self.total_shards = total_shards
         self.identifier_column = video_metadata.identifier_column if video_metadata.identifier_column else 'id'
 
-    def load(self) -> Iterator[FrameBatch]:
+    def load(self) -> Iterator[Batch]:
         """
         This is a generator for loading the frames of a video.
          Uses the video metadata and other class arguments
@@ -66,13 +66,13 @@ class AbstractVideoLoader(metaclass=ABCMeta):
             if self.skip_frames > 0 and record.get(self.identifier_column, 0) % self.skip_frames != 0:
                 continue
             if self.limit and record.get(self.identifier_column, 0) >= self.limit:
-                return FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+                return Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
             frames.append(record)
             if len(frames) % self.batch_size == 0:
-                yield FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+                yield Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
                 frames = []
         if frames:
-            return FrameBatch(pd.DataFrame(frames), identifier_column=self.identifier_column)
+            return Batch(pd.DataFrame(frames), identifier_column=self.identifier_column)
 
     @abstractmethod
     def _load_frames(self) -> Iterator[Dict]:

--- a/src/loaders/petastorm_loader.py
+++ b/src/loaders/petastorm_loader.py
@@ -17,8 +17,6 @@ from typing import Iterator
 from petastorm import make_reader
 
 from src.loaders.abstract_loader import AbstractVideoLoader
-from src.models.catalog.frame_info import FrameInfo
-from src.models.catalog.properties import ColorSpace
 from src.models.storage.frame import Frame
 
 
@@ -35,15 +33,9 @@ class PetastormLoader(AbstractVideoLoader):
             self.total_shards = None
 
     def _load_frames(self) -> Iterator[Frame]:
-        info = None
         with make_reader(self.video_metadata.file_url,
                          shard_count=self.total_shards,
                          cur_shard=self.curr_shard) \
                 as reader:
             for frame_ind, row in enumerate(reader):
-                if info is None:
-                    (height, width, num_channels) = row.frame_data.shape
-                    info = FrameInfo(height, width, num_channels,
-                                     ColorSpace.BGR)
-
-                yield Frame(row.frame_id, row.frame_data, info)
+                yield row._asdict()

--- a/src/loaders/video_loader.py
+++ b/src/loaders/video_loader.py
@@ -17,8 +17,6 @@ from typing import Iterator
 import cv2
 
 from src.loaders.abstract_loader import AbstractVideoLoader
-from src.models.catalog.frame_info import FrameInfo
-from src.models.catalog.properties import ColorSpace
 from src.models.storage.frame import Frame
 from src.utils.logging_manager import LoggingLevel
 from src.utils.logging_manager import LoggingManager
@@ -42,12 +40,7 @@ class VideoLoader(AbstractVideoLoader):
         _, frame = video.read()
         frame_ind = video_start - 1
 
-        info = None
-        if frame is not None:
-            (height, width, num_channels) = frame.shape
-            info = FrameInfo(height, width, num_channels, ColorSpace.BGR)
-
         while frame is not None:
             frame_ind += 1
-            yield Frame(frame_ind, frame, info)
+            yield {'id': frame_ind, 'frame_data': frame}
             _, frame = video.read()

--- a/src/models/inference/classifier_prediction.py
+++ b/src/models/inference/classifier_prediction.py
@@ -30,7 +30,9 @@ class Prediction(BasePrediction):
 
     """
 
-    def __init__(self, frame: Frame, labels: List[str], scores: List[float],
+    def __init__(self, frame: Frame,
+                 labels: List[str],
+                 scores: List[float],
                  boxes: List[BoundingBox] = None):
         self._boxes = boxes
         self._labels = labels
@@ -95,9 +97,9 @@ class Prediction(BasePrediction):
     def __eq__(self, other):
         if isinstance(self, type(other)):
             return self.boxes == other.boxes and \
-                self.frame == other.frame and \
-                self.scores == other.scores and \
-                self.labels == other.labels
+                   self.frame == other.frame and \
+                   self.scores == other.scores and \
+                   self.labels == other.labels
         return other in self
 
     def __contains__(self, item):

--- a/src/models/inference/classifier_prediction.py
+++ b/src/models/inference/classifier_prediction.py
@@ -16,7 +16,7 @@ from typing import List
 
 from src.models.inference.base_prediction import BasePrediction
 from src.models.inference.representation import BoundingBox
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.models.storage.frame import Frame
 
 
@@ -56,7 +56,7 @@ class Prediction(BasePrediction):
         return self._scores
 
     @staticmethod
-    def predictions_from_batch_and_lists(batch: FrameBatch,
+    def predictions_from_batch_and_lists(batch: Batch,
                                          predictions: List[List[str]],
                                          scores: List[List[float]],
                                          boxes: List[
@@ -66,7 +66,7 @@ class Prediction(BasePrediction):
         from identified values
 
         Arguments:
-            batch (FrameBatch): frame batch for which the predictions belong to
+            batch (Batch): frame batch for which the predictions belong to
 
             predictions (List[List[str]]): List of prediction labels per
             frame in batch

--- a/src/models/inference/outcome.py
+++ b/src/models/inference/outcome.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pandas as pd
+
+
+class Outcome:
+    """
+    Data model used to store the outcome of each function.
+
+    Arguments:
+        data (pd.DataFrame): actual pandas dataframe containing the information
+        identifier (str): the identifier string for the outcomes. Default comparisons will be performed on this field.
+    """
+
+    def __init__(self, data: pd.DataFrame, identifier: str):
+        self._data = data
+        self._identifier = identifier
+
+    @property
+    def data(self) -> pd.DataFrame:
+        return self._data
+
+    def __getattr__(self, item):
+        if item in self._data.columns:
+            return Outcome(self._data[[item]], item)
+
+    def __eq__(self, other):
+        if isinstance(other, Outcome):
+            return self._identifier == other._identifier and \
+                   self._data.equals(other._data)
+
+        return len(self._data[self._data[self._identifier] == other]) > 0
+
+    def __le__(self, other):
+        return len(self._data[self._data[self._identifier] <= other]) > 0
+
+    def __ge__(self, other):
+        return len(self._data[self._data[self._identifier] >= other]) > 0
+
+    def __gt__(self, other):
+        return len(self._data[self._data[self._identifier] > other]) > 0
+
+    def __lt__(self, other):
+        return len(self._data[self._data[self._identifier] < other]) > 0
+
+    def __ne__(self, other):
+        return len(self._data[self._data[self._identifier] == other]) == 0

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -21,7 +21,7 @@ from pandas import DataFrame
 from src.models.inference.outcome import Outcome
 
 
-class FrameBatch:
+class Batch:
     """
     Data model used for storing a batch of frames
 
@@ -60,10 +60,10 @@ class FrameBatch:
     def identifier_column(self):
         return self._identifier_column
 
-    def frames_as_numpy_array(self, column_name='data'):
+    def column_as_numpy_array(self, column_name='data'):
         return np.array(self._frames[column_name])
 
-    def __eq__(self, other: 'FrameBatch'):
+    def __eq__(self, other: 'Batch'):
         return self.frames.equals(other.frames) and \
                self._outcomes == other._outcomes and \
                self._temp_outcomes == other._temp_outcomes
@@ -116,7 +116,7 @@ class FrameBatch:
 
     def _get_frames_from_indices(self, required_frame_ids):
         new_frames = self.frames.iloc[required_frame_ids, :]
-        new_batch = FrameBatch(new_frames)
+        new_batch = Batch(new_frames)
         for key in self._outcomes:
             new_batch._outcomes[key] = [self._outcomes[key][i]
                                         for i in required_frame_ids]
@@ -125,7 +125,7 @@ class FrameBatch:
                                              for i in required_frame_ids]
         return new_batch
 
-    def __getitem__(self, indices) -> 'FrameBatch':
+    def __getitem__(self, indices) -> 'Batch':
         """
         Takes as input the slice for the list
         Arguments:
@@ -143,20 +143,20 @@ class FrameBatch:
             step = indices.step if indices.step else 1
             return self._get_frames_from_indices(range(start, end, step))
 
-    def __add__(self, other: 'FrameBatch'):
+    def __add__(self, other: 'Batch'):
         """
         Adds two batch frames and return a new batch frame
         Arguments:
-            other (FrameBatch): other framebatch to add
+            other (Batch): other framebatch to add
 
         Returns:
-            FrameBatch
+            Batch
         """
 
         def _unique_keys(dict1, dict2):
             return set(list(dict1.keys()) + list(dict2.keys()))
 
-        if not isinstance(other, FrameBatch):
+        if not isinstance(other, Batch):
             raise TypeError("Input should be of type -  FrameBatch")
 
         new_frames = self.frames.append(other.frames)
@@ -170,5 +170,5 @@ class FrameBatch:
             temp_new_outcomes[key] = self._temp_outcomes.get(key, []) + \
                                      other._temp_outcomes.get(key, [])
 
-        return FrameBatch(new_frames, outcomes=new_outcomes,
-                          temp_outcomes=temp_new_outcomes)
+        return Batch(new_frames, outcomes=new_outcomes,
+                     temp_outcomes=temp_new_outcomes)

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -30,6 +30,7 @@ class Batch:
         info (FrameInfo): Information about the frames in the batch
         outcomes (Dict[str, List[BasePrediction]]): outcomes of running a udf
         with name 'x' as key
+        identifier_column (str): A column used to uniquely a row
 
 
     """

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -142,3 +142,33 @@ class FrameBatch:
                 end = len(self.frames) + end
             step = indices.step if indices.step else 1
             return self._get_frames_from_indices(range(start, end, step))
+
+    def __add__(self, other: 'FrameBatch'):
+        """
+        Adds two batch frames and return a new batch frame
+        Arguments:
+            other (FrameBatch): other framebatch to add
+
+        Returns:
+            FrameBatch
+        """
+
+        def _unique_keys(dict1, dict2):
+            return set(list(dict1.keys()) + list(dict2.keys()))
+
+        if not isinstance(other, FrameBatch):
+            raise TypeError("Input should be of type -  FrameBatch")
+
+        new_frames = self.frames.append(other.frames)
+        new_outcomes = {}
+        temp_new_outcomes = {}
+
+        for key in _unique_keys(self._outcomes, other._outcomes):
+            new_outcomes[key] = self._outcomes.get(key, []) + \
+                                other._outcomes.get(key, [])
+        for key in _unique_keys(self._temp_outcomes, other._temp_outcomes):
+            temp_new_outcomes[key] = self._temp_outcomes.get(key, []) + \
+                                     other._temp_outcomes.get(key, [])
+
+        return FrameBatch(new_frames, outcomes=new_outcomes,
+                          temp_outcomes=temp_new_outcomes)

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -18,6 +18,8 @@ from typing import List
 import numpy as np
 from pandas import DataFrame
 
+from src.models.inference.outcome import Outcome
+
 
 class FrameBatch:
     """
@@ -66,7 +68,7 @@ class FrameBatch:
                self._outcomes == other._outcomes and \
                self._temp_outcomes == other._temp_outcomes
 
-    def set_outcomes(self, name, predictions: List[pd.DataFrame],
+    def set_outcomes(self, name, predictions: List[Outcome],
                      is_temp: bool = False):
         """
         Used for storing outcomes of the UDF predictions
@@ -80,19 +82,12 @@ class FrameBatch:
             is_temp (bool, default: False): Check if the outcomes are temporary
 
         """
-        outcomes_pd = pd.DataFrame()
-        unique_ids = self.frames[self.identifier_column].unique().tolist()
-        for i in range(len(predictions)):
-            df = predictions[i]
-            df[self.identifier_column] = unique_ids[i]
-            outcomes_pd = outcomes_pd.append(df)
-
         if is_temp:
-            self._temp_outcomes[name] = outcomes_pd
+            self._temp_outcomes[name] = predictions
         else:
-            self._outcomes[name] = outcomes_pd
+            self._outcomes[name] = predictions
 
-    def get_outcomes_for(self, name: str) -> List[pd.DataFrame]:
+    def get_outcomes_for(self, name: str) -> List[Outcome]:
         """
         Returns names corresponding to a name
         Arguments:

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -31,14 +31,13 @@ class FrameBatch:
 
     """
 
-    def __init__(self, frames: DataFrame, info, outcomes=None, temp_outcomes=None):
+    def __init__(self, frames: DataFrame, outcomes=None, temp_outcomes=None):
         super().__init__()
         if outcomes is None:
             outcomes = dict()
         if temp_outcomes is None:
             temp_outcomes = dict()
 
-        self._info = info
         self._frames = frames
         self._batch_size = len(frames)
         self._outcomes = outcomes
@@ -49,10 +48,6 @@ class FrameBatch:
         return self._frames
 
     @property
-    def info(self):
-        return self._info
-
-    @property
     def batch_size(self):
         return self._batch_size
 
@@ -60,8 +55,7 @@ class FrameBatch:
         return np.array(self._frames[column_name])
 
     def __eq__(self, other: 'FrameBatch'):
-        return self.info == other.info and \
-               self.frames.equals(other.frames) and \
+        return self.frames.equals(other.frames) and \
                self._outcomes == other._outcomes and \
                self._temp_outcomes == other._temp_outcomes
 
@@ -113,7 +107,7 @@ class FrameBatch:
 
     def _get_frames_from_indices(self, required_frame_ids):
         new_frames = self.frames.iloc[required_frame_ids, :]
-        new_batch = FrameBatch(new_frames, self.info)
+        new_batch = FrameBatch(new_frames)
         for key in self._outcomes:
             new_batch._outcomes[key] = [self._outcomes[key][i]
                                         for i in required_frame_ids]

--- a/src/parser/parser_visitor.py
+++ b/src/parser/parser_visitor.py
@@ -17,24 +17,20 @@ import warnings
 
 from antlr4 import TerminalNode
 
-from src.expression.abstract_expression import (AbstractExpression,
-                                                ExpressionType)
+from src.expression.abstract_expression import (ExpressionType)
 from src.expression.comparison_expression import ComparisonExpression
 from src.expression.constant_value_expression import ConstantValueExpression
+from src.expression.function_expression import FunctionExpression, \
+    ExecutionMode
 from src.expression.logical_expression import LogicalExpression
 from src.expression.tuple_value_expression import TupleValueExpression
-from src.expression.function_expression import FunctionExpression
-
-from src.parser.select_statement import SelectStatement
 from src.parser.create_statement import CreateTableStatement, ColumnDefinition
-from src.parser.insert_statement import InsertTableStatement
 from src.parser.create_udf_statement import CreateUDFStatement
-
-from src.parser.table_ref import TableRef, TableInfo
-
 from src.parser.evaql.evaql_parser import evaql_parser
 from src.parser.evaql.evaql_parserVisitor import evaql_parserVisitor
-
+from src.parser.insert_statement import InsertTableStatement
+from src.parser.select_statement import SelectStatement
+from src.parser.table_ref import TableRef, TableInfo
 from src.parser.types import ParserColumnDataType
 from src.utils.logging_manager import LoggingLevel, LoggingManager
 
@@ -468,7 +464,6 @@ class ParserVisitor(evaql_parserVisitor):
     ##################################################################
     def visitUdfFunction(self, ctx: evaql_parser.UdfFunctionContext):
         udf_name = None
-        udf_args = None
         if ctx.simpleId():
             udf_name = self.visit(ctx.simpleId())
         else:
@@ -476,7 +471,8 @@ class ParserVisitor(evaql_parserVisitor):
                                  LoggingLevel.ERROR)
 
         udf_args = self.visit(ctx.functionArgs())
-        func_expr = FunctionExpression(None, name=udf_name)
+        func_expr = FunctionExpression(None, name=udf_name,
+                                       mode=ExecutionMode.EXEC)
         for arg in udf_args:
             func_expr.append_child(arg)
         return func_expr

--- a/src/udfs/abstract_udfs.py
+++ b/src/udfs/abstract_udfs.py
@@ -64,6 +64,7 @@ class AbstractClassifierUDF(metaclass=ABCMeta):
         Returns:
             List[DataFrame]: The predictions made by the classifier
         """
+        pass
 
     def __call__(self, *args, **kwargs):
-        self.classify(*args, **kwargs)
+        return self.classify(*args, **kwargs)

--- a/src/udfs/abstract_udfs.py
+++ b/src/udfs/abstract_udfs.py
@@ -15,9 +15,10 @@
 from abc import ABCMeta, abstractmethod
 from typing import List
 
+import numpy as np
+import pandas as pd
+
 from src.models.catalog.frame_info import FrameInfo
-from src.models.inference.base_prediction import BasePrediction
-from src.models.storage.batch import FrameBatch
 
 
 class AbstractClassifierUDF(metaclass=ABCMeta):
@@ -51,17 +52,17 @@ class AbstractClassifierUDF(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def classify(self, batch: FrameBatch) -> List[BasePrediction]:
+    def classify(self, frames: np.ndarray) -> List[pd.DataFrame]:
         """
         Takes as input a batch of frames and returns the predictions by
         applying the classification model.
 
         Arguments:
-            batch (FrameBatch): Input batch of frames on which prediction
+            frames (np.ndarray): Input batch of frames on which prediction
             needs to be made
 
         Returns:
-            List[BasePrediction]: The predictions made by the classifier
+            List[DataFrame]: The predictions made by the classifier
         """
 
     def __call__(self, *args, **kwargs):

--- a/src/udfs/fastrcnn_object_detector.py
+++ b/src/udfs/fastrcnn_object_detector.py
@@ -12,18 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
+import pandas as pd
 import torchvision
 from torchvision import transforms
 
 from src.models.catalog.frame_info import FrameInfo
 from src.models.catalog.properties import ColorSpace
-from src.models.inference.classifier_prediction import Prediction
-from src.models.inference.representation import BoundingBox, Point
-from src.models.storage.batch import FrameBatch
 from src.udfs.abstract_udfs import AbstractClassifierUDF
 
 
@@ -78,10 +75,7 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
             'toothbrush'
         ]
 
-    def _get_predictions(self, frames: np.ndarray) -> Tuple[List[List[str]],
-                                                            List[List[float]],
-                                                            List[List[
-                                                                BoundingBox]]]:
+    def _get_predictions(self, frames: np.ndarray) -> List[pd.DataFrame]:
         """
         Performs predictions on input frames
         Arguments:
@@ -98,13 +92,12 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
         transform = transforms.Compose([transforms.ToTensor()])
         images = [transform(frame) for frame in frames]
         predictions = self.model(images)
-        prediction_boxes = []
-        prediction_classes = []
-        prediction_scores = []
+        prediction_df_list = []
         for prediction in predictions:
             pred_class = [str(self.labels[i]) for i in
-                          list(prediction['labels'].numpy())]
-            pred_boxes = [BoundingBox(Point(i[0], i[1]), Point(i[2], i[3]))
+                          list(prediction['labels'].detach().numpy())]
+            pred_boxes = [[[i[0], i[1]],
+                           [i[2], i[3]]]
                           for i in
                           list(prediction['boxes'].detach().numpy())]
             pred_score = list(prediction['scores'].detach().numpy())
@@ -114,15 +107,9 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
             pred_boxes = list(pred_boxes[:pred_t + 1])
             pred_class = list(pred_class[:pred_t + 1])
             pred_score = list(pred_score[:pred_t + 1])
-            prediction_boxes.append(pred_boxes)
-            prediction_classes.append(pred_class)
-            prediction_scores.append(pred_score)
-        return prediction_classes, prediction_scores, prediction_boxes
+            prediction_df_list.append(
+                pd.DataFrame({"label": pred_class, "pred_score": pred_score, "pred_boxes": pred_boxes}))
+        return prediction_df_list
 
-    def classify(self, batch: FrameBatch) -> List[Prediction]:
-        frames = batch.frames_as_numpy_array()
-        (pred_classes, pred_scores, pred_boxes) = self._get_predictions(frames)
-        return Prediction.predictions_from_batch_and_lists(batch,
-                                                           pred_classes,
-                                                           pred_scores,
-                                                           boxes=pred_boxes)
+    def classify(self, frames: np.ndarray) -> List[pd.DataFrame]:
+        return self._get_predictions(frames)

--- a/src/udfs/fastrcnn_object_detector.py
+++ b/src/udfs/fastrcnn_object_detector.py
@@ -109,8 +109,10 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
             pred_class = list(pred_class[:pred_t + 1])
             pred_score = list(pred_score[:pred_t + 1])
             prediction_df_list.append(
-                Outcome(pd.DataFrame({"label": pred_class, "pred_score": pred_score, "pred_boxes": pred_boxes}),
-                        'label'))
+                Outcome(pd.DataFrame(
+                    {"label": pred_class, "pred_score": pred_score,
+                     "pred_boxes": pred_boxes}),
+                    'label'))
         return prediction_df_list
 
     def classify(self, frames: np.ndarray) -> List[Outcome]:

--- a/src/udfs/fastrcnn_object_detector.py
+++ b/src/udfs/fastrcnn_object_detector.py
@@ -21,6 +21,7 @@ from torchvision import transforms
 
 from src.models.catalog.frame_info import FrameInfo
 from src.models.catalog.properties import ColorSpace
+from src.models.inference.outcome import Outcome
 from src.udfs.abstract_udfs import AbstractClassifierUDF
 
 
@@ -75,7 +76,7 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
             'toothbrush'
         ]
 
-    def _get_predictions(self, frames: np.ndarray) -> List[pd.DataFrame]:
+    def _get_predictions(self, frames: np.ndarray) -> List[Outcome]:
         """
         Performs predictions on input frames
         Arguments:
@@ -108,8 +109,9 @@ class FastRCNNObjectDetector(AbstractClassifierUDF):
             pred_class = list(pred_class[:pred_t + 1])
             pred_score = list(pred_score[:pred_t + 1])
             prediction_df_list.append(
-                pd.DataFrame({"label": pred_class, "pred_score": pred_score, "pred_boxes": pred_boxes}))
+                Outcome(pd.DataFrame({"label": pred_class, "pred_score": pred_score, "pred_boxes": pred_boxes}),
+                        'label'))
         return prediction_df_list
 
-    def classify(self, frames: np.ndarray) -> List[pd.DataFrame]:
+    def classify(self, frames: np.ndarray) -> List[Outcome]:
         return self._get_predictions(frames)

--- a/test/catalog/services/test_dataset_service.py
+++ b/test/catalog/services/test_dataset_service.py
@@ -22,6 +22,7 @@ DATASET_ID = 123
 DATASET_URL = 'file1'
 DATASET_NAME = 'name'
 DATABASE_NAME = "test"
+IDENTIFIER = 'data_id'
 
 
 class DatasetServiceTest(TestCase):
@@ -29,8 +30,8 @@ class DatasetServiceTest(TestCase):
     @patch("src.catalog.services.df_service.DataFrameMetadata")
     def test_create_dataset_should_create_model(self, mocked):
         service = DatasetService()
-        service.create_dataset(DATASET_NAME, DATASET_URL)
-        mocked.assert_called_with(name=DATASET_NAME, file_url=DATASET_URL)
+        service.create_dataset(DATASET_NAME, DATASET_URL, identifier_id=IDENTIFIER)
+        mocked.assert_called_with(name=DATASET_NAME, file_url=DATASET_URL, identifier_id=IDENTIFIER)
         mocked.return_value.save.assert_called_once()
 
     @patch("src.catalog.services.df_service.DataFrameMetadata")

--- a/test/catalog/test_catalog_manager.py
+++ b/test/catalog/test_catalog_manager.py
@@ -45,7 +45,7 @@ class CatalogManagerTests(unittest.TestCase):
         columns = [(DataFrameColumn("c1", ColumnType.INTEGER))]
         actual = catalog.create_metadata(dataset_name, file_url, columns)
         ds_mock.return_value.create_dataset.assert_called_with(dataset_name,
-                                                               file_url)
+                                                               file_url, identifier_id='id')
         for column in columns:
             column.metadata_id = \
                 ds_mock.return_value.create_dataset.return_value.id

--- a/test/catalog/test_catalog_manager.py
+++ b/test/catalog/test_catalog_manager.py
@@ -45,7 +45,8 @@ class CatalogManagerTests(unittest.TestCase):
         columns = [(DataFrameColumn("c1", ColumnType.INTEGER))]
         actual = catalog.create_metadata(dataset_name, file_url, columns)
         ds_mock.return_value.create_dataset.assert_called_with(dataset_name,
-                                                               file_url, identifier_id='id')
+                                                               file_url,
+                                                               identifier_id='id')
         for column in columns:
             column.metadata_id = \
                 ds_mock.return_value.create_dataset.return_value.id
@@ -148,6 +149,14 @@ class CatalogManagerTests(unittest.TestCase):
         udf_mock.return_value.create_udf.assert_called_with(
             'udf', 'sample.py', 'classification')
         self.assertEqual(actual, udf_mock.return_value.create_udf.return_value)
+
+    @mock.patch('src.catalog.catalog_manager.UdfService')
+    def test_get_udf_by_name(self, udf_mock):
+        catalog = CatalogManager()
+        actual = catalog.get_udf_by_name('name')
+        udf_mock.return_value.udf_by_name.assert_called_with('name')
+        self.assertEqual(actual,
+                         udf_mock.return_value.udf_by_name.return_value)
 
 
 if __name__ == '__main__':

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -90,9 +90,7 @@ class PlanExecutorTest(unittest.TestCase):
         # Execute the plan
         executor = PlanExecutor(seq_scan)
         actual = executor.execute_plan()
-        expected = [
-            batch_1[::2],
-            batch_2[::2]]
+        expected = batch_1[::2] + batch_2[::2]
 
         mock_class.assert_called_once()
 

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.executor.plan_executor import PlanExecutor
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.planner.seq_scan_plan import SeqScanPlan
 from src.planner.storage_plan import StoragePlan
 
@@ -77,8 +77,8 @@ class PlanExecutorTest(unittest.TestCase):
 
         # Build plan tree
         video = DataFrameMetadata("dataset", "dummy.avi")
-        batch_1 = FrameBatch(pd.DataFrame({'data': [1, 2, 3]}))
-        batch_2 = FrameBatch(pd.DataFrame({'data': [4, 5, 6]}))
+        batch_1 = Batch(pd.DataFrame({'data': [1, 2, 3]}))
+        batch_2 = Batch(pd.DataFrame({'data': [4, 5, 6]}))
         class_instatnce.load.return_value = map(lambda x: x, [
             batch_1,
             batch_2])

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -77,8 +77,8 @@ class PlanExecutorTest(unittest.TestCase):
 
         # Build plan tree
         video = DataFrameMetadata("dataset", "dummy.avi")
-        batch_1 = FrameBatch(pd.DataFrame({'data': [1, 2, 3]}), None)
-        batch_2 = FrameBatch(pd.DataFrame({'data': [4, 5, 6]}), None)
+        batch_1 = FrameBatch(pd.DataFrame({'data': [1, 2, 3]}))
+        batch_2 = FrameBatch(pd.DataFrame({'data': [4, 5, 6]}))
         class_instatnce.load.return_value = map(lambda x: x, [
             batch_1,
             batch_2])

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pandas as pd
 import unittest
 from unittest.mock import patch
 
@@ -76,9 +77,11 @@ class PlanExecutorTest(unittest.TestCase):
 
         # Build plan tree
         video = DataFrameMetadata("dataset", "dummy.avi")
+        batch_1 = FrameBatch(pd.DataFrame({'data': [1, 2, 3]}), None)
+        batch_2 = FrameBatch(pd.DataFrame({'data': [4, 5, 6]}), None)
         class_instatnce.load.return_value = map(lambda x: x, [
-            FrameBatch([1, 2, 3], None),
-            FrameBatch([4, 5, 6], None)])
+            batch_1,
+            batch_2])
 
         storage_plan = StoragePlan(video)
         seq_scan = SeqScanPlan(predicate=dummy_expr, column_ids=[])
@@ -88,8 +91,8 @@ class PlanExecutorTest(unittest.TestCase):
         executor = PlanExecutor(seq_scan)
         actual = executor.execute_plan()
         expected = [
-            FrameBatch([1, 3], None),
-            FrameBatch([4, 6], None)]
+            batch_1[::2],
+            batch_2[::2]]
 
         mock_class.assert_called_once()
 

--- a/test/executor/test_pp_executor.py
+++ b/test/executor/test_pp_executor.py
@@ -14,25 +14,17 @@
 # limitations under the License.
 import unittest
 
-import numpy as np
-
-from src.models.storage.batch import FrameBatch
-from src.models.storage.frame import Frame
 from src.executor.pp_executor import PPExecutor
+from src.models.storage.batch import FrameBatch
+from test.util import create_dataframe
 from ..executor.utils import DummyExecutor
 
 
 class PPScanExecutorTest(unittest.TestCase):
 
     def test_should_return_only_frames_satisfy_predicate(self):
-        frame_1 = Frame(1, np.ones((1, 1)), None)
-        frame_2 = Frame(1, 2 * np.ones((1, 1)), None)
-        frame_3 = Frame(1, 3 * np.ones((1, 1)), None)
-        batch = FrameBatch(frames=[
-            frame_1,
-            frame_2,
-            frame_3,
-        ], info=None)
+        dataframe = create_dataframe(3)
+        batch = FrameBatch(frames=dataframe, info=None)
         expression = type("AbstractExpression", (), {"evaluate": lambda x: [
             False, False, True]})
 
@@ -40,6 +32,6 @@ class PPScanExecutorTest(unittest.TestCase):
         predicate_executor = PPExecutor(plan)
         predicate_executor.append_child(DummyExecutor([batch]))
 
-        expected = FrameBatch(frames=[frame_3], info=None)
+        expected = batch[[2]]
         filtered = list(predicate_executor.exec())[0]
         self.assertEqual(expected, filtered)

--- a/test/executor/test_pp_executor.py
+++ b/test/executor/test_pp_executor.py
@@ -24,7 +24,7 @@ class PPScanExecutorTest(unittest.TestCase):
 
     def test_should_return_only_frames_satisfy_predicate(self):
         dataframe = create_dataframe(3)
-        batch = FrameBatch(frames=dataframe, info=None)
+        batch = FrameBatch(frames=dataframe)
         expression = type("AbstractExpression", (), {"evaluate": lambda x: [
             False, False, True]})
 

--- a/test/executor/test_pp_executor.py
+++ b/test/executor/test_pp_executor.py
@@ -15,7 +15,7 @@
 import unittest
 
 from src.executor.pp_executor import PPExecutor
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from test.util import create_dataframe
 from ..executor.utils import DummyExecutor
 
@@ -24,7 +24,7 @@ class PPScanExecutorTest(unittest.TestCase):
 
     def test_should_return_only_frames_satisfy_predicate(self):
         dataframe = create_dataframe(3)
-        batch = FrameBatch(frames=dataframe)
+        batch = Batch(frames=dataframe)
         expression = type("AbstractExpression", (), {"evaluate": lambda x: [
             False, False, True]})
 

--- a/test/executor/test_seq_scan_executor.py
+++ b/test/executor/test_seq_scan_executor.py
@@ -14,29 +14,22 @@
 # limitations under the License.
 import unittest
 
-import numpy as np
-
+from src.executor.seq_scan_executor import SequentialScanExecutor
 from src.models.inference.classifier_prediction import Prediction
 from src.models.storage.batch import FrameBatch
-from src.models.storage.frame import Frame
-from src.executor.seq_scan_executor import SequentialScanExecutor
+from test.util import create_dataframe
 from ..executor.utils import DummyExecutor
 
 
 class SeqScanExecutorTest(unittest.TestCase):
 
     def test_should_return_only_frames_satisfy_predicate(self):
-        frame_1 = Frame(1, np.ones((1, 1)), None)
-        frame_2 = Frame(1, 2 * np.ones((1, 1)), None)
-        frame_3 = Frame(1, 3 * np.ones((1, 1)), None)
-        outcome_1 = Prediction(frame_1, ["car", "bus"], [0.5, 0.6])
-        outcome_2 = Prediction(frame_2, ["bus"], [0.5, 0.6])
-        outcome_3 = Prediction(frame_3, ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=[
-            frame_1,
-            frame_2,
-            frame_3,
-        ], info=None, outcomes={
+        dataframe = create_dataframe(3)
+
+        outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
+        outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
+        outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
+        batch = FrameBatch(frames=dataframe, info=None, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,
@@ -50,23 +43,17 @@ class SeqScanExecutorTest(unittest.TestCase):
         predicate_executor = SequentialScanExecutor(plan)
         predicate_executor.append_child(DummyExecutor([batch]))
 
-        expected = FrameBatch(frames=[frame_3], info=None,
-                              outcomes={"test": [outcome_3]})
+        expected = batch[[2]]
         filtered = list(predicate_executor.exec())[0]
         self.assertEqual(expected, filtered)
 
     def test_should_return_all_frames_when_no_predicate_is_applied(self):
-        frame_1 = Frame(1, np.ones((1, 1)), None)
-        frame_2 = Frame(1, 2 * np.ones((1, 1)), None)
-        frame_3 = Frame(1, 3 * np.ones((1, 1)), None)
-        outcome_1 = Prediction(frame_1, ["car", "bus"], [0.5, 0.6])
-        outcome_2 = Prediction(frame_2, ["bus"], [0.5, 0.6])
-        outcome_3 = Prediction(frame_3, ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=[
-            frame_1,
-            frame_2,
-            frame_3,
-        ], info=None, outcomes={
+        dataframe = create_dataframe(3)
+
+        outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
+        outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
+        outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
+        batch = FrameBatch(frames=dataframe, info=None, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,
@@ -78,8 +65,5 @@ class SeqScanExecutorTest(unittest.TestCase):
         predicate_executor = SequentialScanExecutor(plan)
         predicate_executor.append_child(DummyExecutor([batch]))
 
-        expected = FrameBatch(frames=[frame_1, frame_2, frame_3], info=None,
-                              outcomes={"test": [outcome_1, outcome_2,
-                                                 outcome_3]})
         filtered = list(predicate_executor.exec())[0]
-        self.assertEqual(expected, filtered)
+        self.assertEqual(batch, filtered)

--- a/test/executor/test_seq_scan_executor.py
+++ b/test/executor/test_seq_scan_executor.py
@@ -16,7 +16,7 @@ import unittest
 
 from src.executor.seq_scan_executor import SequentialScanExecutor
 from src.models.inference.classifier_prediction import Prediction
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from test.util import create_dataframe
 from ..executor.utils import DummyExecutor
 
@@ -29,7 +29,7 @@ class SeqScanExecutorTest(unittest.TestCase):
         outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
         outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
         outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=dataframe, outcomes={
+        batch = Batch(frames=dataframe, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,
@@ -53,7 +53,7 @@ class SeqScanExecutorTest(unittest.TestCase):
         outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
         outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
         outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=dataframe, outcomes={
+        batch = Batch(frames=dataframe, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,

--- a/test/executor/test_seq_scan_executor.py
+++ b/test/executor/test_seq_scan_executor.py
@@ -29,7 +29,7 @@ class SeqScanExecutorTest(unittest.TestCase):
         outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
         outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
         outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=dataframe, info=None, outcomes={
+        batch = FrameBatch(frames=dataframe, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,
@@ -53,7 +53,7 @@ class SeqScanExecutorTest(unittest.TestCase):
         outcome_1 = Prediction(dataframe.iloc[0], ["car", "bus"], [0.5, 0.6])
         outcome_2 = Prediction(dataframe.iloc[1], ["bus"], [0.5, 0.6])
         outcome_3 = Prediction(dataframe.iloc[2], ["car", "train"], [0.5, 0.6])
-        batch = FrameBatch(frames=dataframe, info=None, outcomes={
+        batch = FrameBatch(frames=dataframe, outcomes={
             "test": [
                 outcome_1,
                 outcome_2,

--- a/test/executor/utils.py
+++ b/test/executor/utils.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 from typing import List
 
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 
 
 class DummyExecutor:
-    def __init__(self, batch_list: List[FrameBatch]):
+    def __init__(self, batch_list: List[Batch]):
         self.batch_list = batch_list
 
     def exec(self):

--- a/test/expression/test_aggregation.py
+++ b/test/expression/test_aggregation.py
@@ -18,7 +18,7 @@ import unittest
 from src.expression.abstract_expression import ExpressionType
 from src.expression.aggregation_expression import AggregationExpression
 from src.expression.tuple_value_expression import TupleValueExpression
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 
 
 class AggregationExpressionsTest(unittest.TestCase):
@@ -33,7 +33,7 @@ class AggregationExpressionsTest(unittest.TestCase):
             None,
             columnName
         )
-        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
+        tuples = Batch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(6, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_count(self):
@@ -43,7 +43,7 @@ class AggregationExpressionsTest(unittest.TestCase):
             None,
             columnName
         )
-        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
+        tuples = Batch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(3, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_avg(self):
@@ -53,7 +53,7 @@ class AggregationExpressionsTest(unittest.TestCase):
             None,
             columnName
         )
-        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
+        tuples = Batch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(2, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_min(self):
@@ -63,7 +63,7 @@ class AggregationExpressionsTest(unittest.TestCase):
             None,
             columnName
         )
-        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
+        tuples = Batch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(1, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_max(self):
@@ -73,5 +73,5 @@ class AggregationExpressionsTest(unittest.TestCase):
             None,
             columnName
         )
-        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
+        tuples = Batch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(3, aggr_expr.evaluate(tuples, None))

--- a/test/expression/test_aggregation.py
+++ b/test/expression/test_aggregation.py
@@ -12,11 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pandas as pd
 import unittest
 
 from src.expression.abstract_expression import ExpressionType
 from src.expression.aggregation_expression import AggregationExpression
 from src.expression.tuple_value_expression import TupleValueExpression
+from src.models.storage.batch import FrameBatch
 
 
 class AggregationExpressionsTest(unittest.TestCase):
@@ -25,51 +27,51 @@ class AggregationExpressionsTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
     def test_aggregation_sum(self):
-        columnName = TupleValueExpression(col_idx=0)
+        columnName = TupleValueExpression(col_name=0)
         aggr_expr = AggregationExpression(
             ExpressionType.AGGREGATION_SUM,
             None,
             columnName
         )
-        tuples = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(6, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_count(self):
-        columnName = TupleValueExpression(col_idx=0)
+        columnName = TupleValueExpression(col_name=0)
         aggr_expr = AggregationExpression(
             ExpressionType.AGGREGATION_COUNT,
             None,
             columnName
         )
-        tuples = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(3, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_avg(self):
-        columnName = TupleValueExpression(col_idx=0)
+        columnName = TupleValueExpression(col_name=0)
         aggr_expr = AggregationExpression(
             ExpressionType.AGGREGATION_AVG,
             None,
             columnName
         )
-        tuples = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(2, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_min(self):
-        columnName = TupleValueExpression(col_idx=0)
+        columnName = TupleValueExpression(col_name=0)
         aggr_expr = AggregationExpression(
             ExpressionType.AGGREGATION_MIN,
             None,
             columnName
         )
-        tuples = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(1, aggr_expr.evaluate(tuples, None))
 
     def test_aggregation_max(self):
-        columnName = TupleValueExpression(col_idx=0)
+        columnName = TupleValueExpression(col_name=0)
         aggr_expr = AggregationExpression(
             ExpressionType.AGGREGATION_MAX,
             None,
             columnName
         )
-        tuples = [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+        tuples = FrameBatch(pd.DataFrame({0: [1, 2, 3], 1: [2, 3, 4], 2: [3, 4, 5]}))
         self.assertEqual(3, aggr_expr.evaluate(tuples, None))

--- a/test/expression/test_expression_tree.py
+++ b/test/expression/test_expression_tree.py
@@ -21,7 +21,7 @@ from src.expression.comparison_expression import ComparisonExpression
 from src.expression.constant_value_expression import ConstantValueExpression
 from src.expression.function_expression import FunctionExpression
 from src.models.inference.classifier_prediction import Prediction
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.models.storage.frame import Frame
 
 
@@ -38,7 +38,7 @@ class ExpressionEvaluationTest(unittest.TestCase):
                                                func,
                                                value_expr)
 
-        batch = FrameBatch(frames=[
+        batch = Batch(frames=[
             frame_1, frame_2
         ])
 

--- a/test/expression/test_expression_tree.py
+++ b/test/expression/test_expression_tree.py
@@ -40,6 +40,6 @@ class ExpressionEvaluationTest(unittest.TestCase):
 
         batch = FrameBatch(frames=[
             frame_1, frame_2
-        ], info=None)
+        ])
 
         self.assertEqual([True, False], expression_tree.evaluate(batch))

--- a/test/expression/test_function_expression.py
+++ b/test/expression/test_function_expression.py
@@ -32,9 +32,8 @@ class FunctionExpressionTest(unittest.TestCase):
         values = [1, 2, 3]
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC, name="test")
-        expected_batch = FrameBatch(frames=pd.DataFrame(), info=None,
-                                    outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=pd.DataFrame(), info=None)
+        expected_batch = FrameBatch(frames=pd.DataFrame(), outcomes={"test": [1, 2, 3]})
+        input_batch = FrameBatch(frames=pd.DataFrame())
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)
 
@@ -59,8 +58,7 @@ class FunctionExpressionTest(unittest.TestCase):
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC,
                                         name="test", is_temp=True)
-        expected_batch = FrameBatch(frames=pd.DataFrame(), info=None,
-                                    temp_outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=pd.DataFrame(), info=None)
+        expected_batch = FrameBatch(frames=pd.DataFrame(), temp_outcomes={"test": [1, 2, 3]})
+        input_batch = FrameBatch(frames=pd.DataFrame())
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)

--- a/test/expression/test_function_expression.py
+++ b/test/expression/test_function_expression.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 import unittest
 
+import pandas as pd
+
 from src.expression.function_expression import FunctionExpression, \
     ExecutionMode
 from src.models.storage.batch import FrameBatch
@@ -30,9 +32,9 @@ class FunctionExpressionTest(unittest.TestCase):
         values = [1, 2, 3]
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC, name="test")
-        expected_batch = FrameBatch(frames=[], info=None,
+        expected_batch = FrameBatch(frames=pd.DataFrame(), info=None,
                                     outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=[], info=None)
+        input_batch = FrameBatch(frames=pd.DataFrame(), info=None)
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)
 
@@ -57,8 +59,8 @@ class FunctionExpressionTest(unittest.TestCase):
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC,
                                         name="test", is_temp=True)
-        expected_batch = FrameBatch(frames=[], info=None,
+        expected_batch = FrameBatch(frames=pd.DataFrame(), info=None,
                                     temp_outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=[], info=None)
+        input_batch = FrameBatch(frames=pd.DataFrame(), info=None)
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)

--- a/test/expression/test_function_expression.py
+++ b/test/expression/test_function_expression.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from src.expression.function_expression import FunctionExpression, \
     ExecutionMode
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 
 
 class FunctionExpressionTest(unittest.TestCase):
@@ -32,8 +32,8 @@ class FunctionExpressionTest(unittest.TestCase):
         values = [1, 2, 3]
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC, name="test")
-        expected_batch = FrameBatch(frames=pd.DataFrame(), outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=pd.DataFrame())
+        expected_batch = Batch(frames=pd.DataFrame(), outcomes={"test": [1, 2, 3]})
+        input_batch = Batch(frames=pd.DataFrame())
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)
 
@@ -58,7 +58,7 @@ class FunctionExpressionTest(unittest.TestCase):
         expression = FunctionExpression(lambda x: values,
                                         mode=ExecutionMode.EXEC,
                                         name="test", is_temp=True)
-        expected_batch = FrameBatch(frames=pd.DataFrame(), temp_outcomes={"test": [1, 2, 3]})
-        input_batch = FrameBatch(frames=pd.DataFrame())
+        expected_batch = Batch(frames=pd.DataFrame(), temp_outcomes={"test": [1, 2, 3]})
+        input_batch = Batch(frames=pd.DataFrame())
         expression.evaluate(input_batch)
         self.assertEqual(expected_batch, input_batch)

--- a/test/models/test_frame_batch.py
+++ b/test/models/test_frame_batch.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from test.util import create_dataframe_same, create_dataframe
 
 NUM_FRAMES = 10
@@ -27,89 +27,89 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_set_outcomes_method_should_set_the_predictions_with_udf_name(
             self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
         batch.set_outcomes('test', [None])
         self.assertEqual([None], batch.get_outcomes_for('test'))
 
     def test_get_outcome_from_non_existing_udf_name_returns_empty_list(self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
         self.assertEqual([], batch.get_outcomes_for('test'))
 
     def test_frames_as_numpy_array_should_frames_as_numpy_array(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe_same(2))
         expected = list(np.ones((2, 1, 1)))
-        actual = list(batch.frames_as_numpy_array())
+        actual = list(batch.column_as_numpy_array())
         self.assertEqual(expected, actual)
 
     def test_return_only_frames_specified_in_the_indices(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe(2))
-        expected = FrameBatch(frames=create_dataframe())
+        expected = Batch(frames=create_dataframe())
         output = batch[[0]]
         self.assertEqual(expected, output)
 
     def test_fetching_frames_by_index_should_also_return_outcomes(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe_same(2),
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=create_dataframe(),
-                              outcomes={'test': [[None]]})
+        expected = Batch(frames=create_dataframe(),
+                         outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[[0]])
 
     def test_slicing_on_batched_should_return_new_batch_frame(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe(2),
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=create_dataframe(),
-                              outcomes={'test': [[None]]})
+        expected = Batch(frames=create_dataframe(),
+                         outcomes={'test': [[None]]})
         self.assertEqual(batch, batch[:])
         self.assertEqual(expected, batch[:-1])
 
     def test_slicing_should_word_for_negative_stop_value(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe(2),
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=create_dataframe(),
-                              outcomes={'test': [[None]]})
+        expected = Batch(frames=create_dataframe(),
+                         outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[:-1])
 
     def test_slicing_should_work_with_skip_value(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe(3),
             outcomes={'test': [[None], [None], [None]]})
-        expected = FrameBatch(
+        expected = Batch(
             frames=create_dataframe(3).iloc[[0, 2], :],
             outcomes={'test': [[None], [None]]})
         self.assertEqual(expected, batch[::2])
 
     def test_fetching_frames_by_index_should_also_return_temp_outcomes(self):
-        batch = FrameBatch(
+        batch = Batch(
             frames=create_dataframe_same(2),
             outcomes={'test': [[1], [2]]},
             temp_outcomes={'test2': [[3], [4]]})
-        expected = FrameBatch(frames=create_dataframe(),
-                              outcomes={'test': [[1]]},
-                              temp_outcomes={'test2': [[3]]})
+        expected = Batch(frames=create_dataframe(),
+                         outcomes={'test': [[1]]},
+                         temp_outcomes={'test2': [[3]]})
         self.assertEqual(expected, batch[[0]])
 
     def test_set_outcomes_method_should_set_temp_outcome_when_bool_is_true(
             self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
         batch.set_outcomes('test', [1], is_temp=True)
-        expected = FrameBatch(frames=create_dataframe(),
-                              temp_outcomes={'test': [1]})
+        expected = Batch(frames=create_dataframe(),
+                         temp_outcomes={'test': [1]})
         self.assertEqual(expected, batch)
 
     def test_has_outcomes_returns_false_if_the_given_name_not_in_outcomes(
             self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
 
         self.assertFalse(batch.has_outcome('temp'))
 
     def test_has_outcomes_returns_true_if_the_given_name_is_in_outcomes(
             self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
         batch.set_outcomes('test_temp', [1], is_temp=True)
         batch.set_outcomes('test', [1])
 
@@ -117,30 +117,30 @@ class FrameBatchTest(unittest.TestCase):
         self.assertTrue(batch.has_outcome('test_temp'))
 
     def test_add_should_raise_error_for_incompatible_type(self):
-        batch = FrameBatch(frames=create_dataframe())
+        batch = Batch(frames=create_dataframe())
         with self.assertRaises(TypeError):
             batch + 1
 
     def test_add_should_get_new_batch_frame_with_addition_no_outcomes(self):
-        batch_1 = FrameBatch(frames=create_dataframe())
-        batch_2 = FrameBatch(frames=create_dataframe())
-        batch_3 = FrameBatch(frames=create_dataframe_same(2))
+        batch_1 = Batch(frames=create_dataframe())
+        batch_2 = Batch(frames=create_dataframe())
+        batch_3 = Batch(frames=create_dataframe_same(2))
         self.assertEqual(batch_3, batch_1 + batch_2)
 
     def test_adding_to_empty_frame_batch_returns_itself(self):
-        batch_1 = FrameBatch(frames=pd.DataFrame())
-        batch_2 = FrameBatch(frames=create_dataframe(), outcomes={'1': [1]})
+        batch_1 = Batch(frames=pd.DataFrame())
+        batch_2 = Batch(frames=create_dataframe(), outcomes={'1': [1]})
 
         self.assertEqual(batch_2, batch_1 + batch_2)
 
     def test_adding_batch_frame_with_outcomes_returns_new_batch_frame(self):
-        batch_1 = FrameBatch(frames=create_dataframe(), outcomes={'1': [1]},
-                             temp_outcomes={'2': [1]})
-        batch_2 = FrameBatch(frames=create_dataframe(), outcomes={'1': [2]},
-                             temp_outcomes={'2': [2]})
+        batch_1 = Batch(frames=create_dataframe(), outcomes={'1': [1]},
+                        temp_outcomes={'2': [1]})
+        batch_2 = Batch(frames=create_dataframe(), outcomes={'1': [2]},
+                        temp_outcomes={'2': [2]})
 
-        batch_3 = FrameBatch(frames=create_dataframe_same(2),
-                             outcomes={'1': [1, 2]},
-                             temp_outcomes={'2': [1, 2]})
+        batch_3 = Batch(frames=create_dataframe_same(2),
+                        outcomes={'1': [1, 2]},
+                        temp_outcomes={'2': [1, 2]})
 
         self.assertEqual(batch_3, batch_1 + batch_2)

--- a/test/models/test_frame_batch.py
+++ b/test/models/test_frame_batch.py
@@ -26,48 +26,41 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_set_outcomes_method_should_set_the_predictions_with_udf_name(
             self):
-        batch = FrameBatch(frames=create_dataframe(), info=None)
+        batch = FrameBatch(frames=create_dataframe())
         batch.set_outcomes('test', [None])
         self.assertEqual([None], batch.get_outcomes_for('test'))
 
     def test_get_outcome_from_non_existing_udf_name_returns_empty_list(self):
-        batch = FrameBatch(frames=create_dataframe(), info=None)
+        batch = FrameBatch(frames=create_dataframe())
         self.assertEqual([], batch.get_outcomes_for('test'))
 
     def test_frames_as_numpy_array_should_frames_as_numpy_array(self):
         batch = FrameBatch(
-            frames=create_dataframe_same(2),
-            info=None)
+            frames=create_dataframe_same(2))
         expected = list(np.ones((2, 1, 1)))
         actual = list(batch.frames_as_numpy_array())
         self.assertEqual(expected, actual)
 
     def test_return_only_frames_specified_in_the_indices(self):
         batch = FrameBatch(
-            frames=create_dataframe(2),
-            info=None)
-        expected = FrameBatch(frames=create_dataframe(),
-                              info=None)
+            frames=create_dataframe(2))
+        expected = FrameBatch(frames=create_dataframe())
         output = batch[[0]]
         self.assertEqual(expected, output)
 
     def test_fetching_frames_by_index_should_also_return_outcomes(self):
         batch = FrameBatch(
             frames=create_dataframe_same(2),
-            info=None,
             outcomes={'test': [[None], [None]]})
         expected = FrameBatch(frames=create_dataframe(),
-                              info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[[0]])
 
     def test_slicing_on_batched_should_return_new_batch_frame(self):
         batch = FrameBatch(
             frames=create_dataframe(2),
-            info=None,
             outcomes={'test': [[None], [None]]})
         expected = FrameBatch(frames=create_dataframe(),
-                              info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(batch, batch[:])
         self.assertEqual(expected, batch[:-1])
@@ -75,52 +68,46 @@ class FrameBatchTest(unittest.TestCase):
     def test_slicing_should_word_for_negative_stop_value(self):
         batch = FrameBatch(
             frames=create_dataframe(2),
-            info=None,
             outcomes={'test': [[None], [None]]})
         expected = FrameBatch(frames=create_dataframe(),
-                              info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[:-1])
 
     def test_slicing_should_work_with_skip_value(self):
         batch = FrameBatch(
-            frames=create_dataframe(3), info=None,
-            outcomes={'test': [[None], [None], [None]]})
+            frames=create_dataframe(3), outcomes={'test': [[None], [None], [None]]})
         expected = FrameBatch(
             frames=create_dataframe(3).iloc[[0, 2], :],
-            info=None,
             outcomes={'test': [[None], [None]]})
         self.assertEqual(expected, batch[::2])
 
     def test_fetching_frames_by_index_should_also_return_temp_outcomes(self):
         batch = FrameBatch(
             frames=create_dataframe_same(2),
-            info=None,
             outcomes={'test': [[1], [2]]},
             temp_outcomes={'test2': [[3], [4]]})
         expected = FrameBatch(frames=create_dataframe(),
-                              info=None,
                               outcomes={'test': [[1]]},
                               temp_outcomes={'test2': [[3]]})
         self.assertEqual(expected, batch[[0]])
 
     def test_set_outcomes_method_should_set_temp_outcome_when_bool_is_true(
             self):
-        batch = FrameBatch(frames=create_dataframe(), info=None)
+        batch = FrameBatch(frames=create_dataframe())
         batch.set_outcomes('test', [1], is_temp=True)
         expected = FrameBatch(frames=create_dataframe(),
-                              info=None, temp_outcomes={'test': [1]})
+                              temp_outcomes={'test': [1]})
         self.assertEqual(expected, batch)
 
     def test_has_outcomes_returns_false_if_the_given_name_not_in_outcomes(
             self):
-        batch = FrameBatch(frames=create_dataframe(), info=None)
+        batch = FrameBatch(frames=create_dataframe())
 
         self.assertFalse(batch.has_outcome('temp'))
 
     def test_has_outcomes_returns_true_if_the_given_name_is_in_outcomes(
             self):
-        batch = FrameBatch(frames=create_dataframe(), info=None)
+        batch = FrameBatch(frames=create_dataframe())
         batch.set_outcomes('test_temp', [1], is_temp=True)
         batch.set_outcomes('test', [1])
 

--- a/test/models/test_frame_batch.py
+++ b/test/models/test_frame_batch.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 from src.models.storage.batch import FrameBatch
-from src.models.storage.frame import Frame
+from test.util import create_dataframe_same, create_dataframe
 
 NUM_FRAMES = 10
 
@@ -26,18 +26,17 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_set_outcomes_method_should_set_the_predictions_with_udf_name(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=create_dataframe(), info=None)
         batch.set_outcomes('test', [None])
         self.assertEqual([None], batch.get_outcomes_for('test'))
 
     def test_get_outcome_from_non_existing_udf_name_returns_empty_list(self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=create_dataframe(), info=None)
         self.assertEqual([], batch.get_outcomes_for('test'))
 
     def test_frames_as_numpy_array_should_frames_as_numpy_array(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)],
+            frames=create_dataframe_same(2),
             info=None)
         expected = list(np.ones((2, 1, 1)))
         actual = list(batch.frames_as_numpy_array())
@@ -45,32 +44,29 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_return_only_frames_specified_in_the_indices(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)],
+            frames=create_dataframe(2),
             info=None)
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None)
         output = batch[[0]]
         self.assertEqual(expected, output)
 
     def test_fetching_frames_by_index_should_also_return_outcomes(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)],
+            frames=create_dataframe_same(2),
             info=None,
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[[0]])
 
     def test_slicing_on_batched_should_return_new_batch_frame(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, 2 * np.ones((1, 1)), None)],
+            frames=create_dataframe(2),
             info=None,
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(batch, batch[:])
@@ -78,36 +74,31 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_slicing_should_word_for_negative_stop_value(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, 2 * np.ones((1, 1)), None)],
+            frames=create_dataframe(2),
             info=None,
             outcomes={'test': [[None], [None]]})
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None,
                               outcomes={'test': [[None]]})
         self.assertEqual(expected, batch[:-1])
 
     def test_slicing_should_work_with_skip_value(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, 2 * np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)], info=None,
+            frames=create_dataframe(3), info=None,
             outcomes={'test': [[None], [None], [None]]})
         expected = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)],
+            frames=create_dataframe(3).iloc[[0, 2], :],
             info=None,
             outcomes={'test': [[None], [None]]})
         self.assertEqual(expected, batch[::2])
 
     def test_fetching_frames_by_index_should_also_return_temp_outcomes(self):
         batch = FrameBatch(
-            frames=[Frame(1, np.ones((1, 1)), None),
-                    Frame(1, np.ones((1, 1)), None)],
+            frames=create_dataframe_same(2),
             info=None,
             outcomes={'test': [[1], [2]]},
             temp_outcomes={'test2': [[3], [4]]})
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None,
                               outcomes={'test': [[1]]},
                               temp_outcomes={'test2': [[3]]})
@@ -115,21 +106,21 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_set_outcomes_method_should_set_temp_outcome_when_bool_is_true(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=create_dataframe(), info=None)
         batch.set_outcomes('test', [1], is_temp=True)
-        expected = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)],
+        expected = FrameBatch(frames=create_dataframe(),
                               info=None, temp_outcomes={'test': [1]})
         self.assertEqual(expected, batch)
 
     def test_has_outcomes_returns_false_if_the_given_name_not_in_outcomes(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=create_dataframe(), info=None)
 
         self.assertFalse(batch.has_outcome('temp'))
 
     def test_has_outcomes_returns_true_if_the_given_name_is_in_outcomes(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=create_dataframe(), info=None)
         batch.set_outcomes('test_temp', [1], is_temp=True)
         batch.set_outcomes('test', [1])
 

--- a/test/models/test_frame_batch.py
+++ b/test/models/test_frame_batch.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pandas as pd
 import unittest
 
 import numpy as np
@@ -75,7 +76,8 @@ class FrameBatchTest(unittest.TestCase):
 
     def test_slicing_should_work_with_skip_value(self):
         batch = FrameBatch(
-            frames=create_dataframe(3), outcomes={'test': [[None], [None], [None]]})
+            frames=create_dataframe(3),
+            outcomes={'test': [[None], [None], [None]]})
         expected = FrameBatch(
             frames=create_dataframe(3).iloc[[0, 2], :],
             outcomes={'test': [[None], [None]]})
@@ -113,3 +115,32 @@ class FrameBatchTest(unittest.TestCase):
 
         self.assertTrue(batch.has_outcome('test'))
         self.assertTrue(batch.has_outcome('test_temp'))
+
+    def test_add_should_raise_error_for_incompatible_type(self):
+        batch = FrameBatch(frames=create_dataframe())
+        with self.assertRaises(TypeError):
+            batch + 1
+
+    def test_add_should_get_new_batch_frame_with_addition_no_outcomes(self):
+        batch_1 = FrameBatch(frames=create_dataframe())
+        batch_2 = FrameBatch(frames=create_dataframe())
+        batch_3 = FrameBatch(frames=create_dataframe_same(2))
+        self.assertEqual(batch_3, batch_1 + batch_2)
+
+    def test_adding_to_empty_frame_batch_returns_itself(self):
+        batch_1 = FrameBatch(frames=pd.DataFrame())
+        batch_2 = FrameBatch(frames=create_dataframe(), outcomes={'1': [1]})
+
+        self.assertEqual(batch_2, batch_1 + batch_2)
+
+    def test_adding_batch_frame_with_outcomes_returns_new_batch_frame(self):
+        batch_1 = FrameBatch(frames=create_dataframe(), outcomes={'1': [1]},
+                             temp_outcomes={'2': [1]})
+        batch_2 = FrameBatch(frames=create_dataframe(), outcomes={'1': [2]},
+                             temp_outcomes={'2': [2]})
+
+        batch_3 = FrameBatch(frames=create_dataframe_same(2),
+                             outcomes={'1': [1, 2]},
+                             temp_outcomes={'2': [1, 2]})
+
+        self.assertEqual(batch_3, batch_1 + batch_2)

--- a/test/models/test_outcome.py
+++ b/test/models/test_outcome.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pandas as pd
+import unittest
+
+from src.models.inference.outcome import Outcome
+
+
+class OutcomeTest(unittest.TestCase):
+    def test_get_attribute_should_return_new_outcome(self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        expected = Outcome(data[["A"]], identifier='A')
+        self.assertEqual(outcome.A, expected)
+
+    def test_equals_should_return_true_if_alreast_one_value_equal(self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(getattr(outcome, 'A') == 1)
+
+    def test_equals_should_return_false_frame_if_no_value_in_data_frame_equal(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A == 4)
+
+    def test_gt_should_return_false_if_no_value_gt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A > 4)
+
+    def test_gt_should_return_true_if_atleast_one_value_gt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome.A > 2)
+
+    def test_gt_should_return_false_if_no_value_gt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A > 4)
+
+    def test_gt_should_return_true_if_atleast_one_value_gt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome.A > 2)
+
+    def test_gte_should_return_false_if_no_value_gte_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A >= 4)
+
+    def test_gte_should_return_true_if_atleast_one_value_gte_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome.A >= 3)
+
+    def test_lt_should_return_false_if_no_value_lt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A < 0)
+
+    def test_lt_should_return_true_if_atleast_one_value_lt_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome.A < 4)
+
+    def test_lte_should_return_false_if_no_value_lte_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A < 1)
+
+    def test_lte_should_return_true_if_atleast_one_value_lte_given(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome.A <= 3)
+
+    def test_ne_should_return_false_if_value_present_atleast_once(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertFalse(outcome.A != 1)
+
+    def test_ne_should_return_true_if_value_not_present(
+            self):
+        data = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+        outcome = Outcome(data, identifier='A')
+        self.assertTrue(outcome != 4)

--- a/test/models/test_prediction.py
+++ b/test/models/test_prediction.py
@@ -27,7 +27,7 @@ class PredictionTest(unittest.TestCase):
 
     def test_should_check_if_batch_frames_equivalent_to_number_of_predictions(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = []
         scores = []
         self.assertRaises(AssertionError,
@@ -36,7 +36,7 @@ class PredictionTest(unittest.TestCase):
                               batch, predictions, scores))
 
     def test_should_check_if_batch_frames_equivalent_to_number_of_scores(self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = []
         self.assertRaises(AssertionError,
@@ -46,7 +46,7 @@ class PredictionTest(unittest.TestCase):
 
     def test_should_check_if_batch_frames_equivalent_to_no_of_boxes_if_given(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = [[1, 1]]
         boxes = []
@@ -57,7 +57,7 @@ class PredictionTest(unittest.TestCase):
                               boxes=boxes))
 
     def test_should_return_list_of_predictions_for_each_frame_in_batch(self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)], info=None)
+        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = [[1, 1]]
         expected = [Prediction(batch.frames[0], predictions[0], scores[0])]

--- a/test/models/test_prediction.py
+++ b/test/models/test_prediction.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 from src.models.inference.classifier_prediction import Prediction
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.models.storage.frame import Frame
 
 NUM_FRAMES = 10
@@ -27,7 +27,7 @@ class PredictionTest(unittest.TestCase):
 
     def test_should_check_if_batch_frames_equivalent_to_number_of_predictions(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
+        batch = Batch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = []
         scores = []
         self.assertRaises(AssertionError,
@@ -36,7 +36,7 @@ class PredictionTest(unittest.TestCase):
                               batch, predictions, scores))
 
     def test_should_check_if_batch_frames_equivalent_to_number_of_scores(self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
+        batch = Batch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = []
         self.assertRaises(AssertionError,
@@ -46,7 +46,7 @@ class PredictionTest(unittest.TestCase):
 
     def test_should_check_if_batch_frames_equivalent_to_no_of_boxes_if_given(
             self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
+        batch = Batch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = [[1, 1]]
         boxes = []
@@ -57,7 +57,7 @@ class PredictionTest(unittest.TestCase):
                               boxes=boxes))
 
     def test_should_return_list_of_predictions_for_each_frame_in_batch(self):
-        batch = FrameBatch(frames=[Frame(1, np.ones((1, 1)), None)])
+        batch = Batch(frames=[Frame(1, np.ones((1, 1)), None)])
         predictions = [['A', 'B']]
         scores = [[1, 1]]
         expected = [Prediction(batch.frames[0], predictions[0], scores[0])]

--- a/test/parser/test_parser_visitor.py
+++ b/test/parser/test_parser_visitor.py
@@ -21,7 +21,8 @@ from unittest.mock import MagicMock, call
 from src.parser.parser_visitor import ParserVisitor
 from src.parser.evaql.evaql_parser import evaql_parser
 from src.expression.abstract_expression import ExpressionType
-from src.expression.function_expression import FunctionExpression
+from src.expression.function_expression import FunctionExpression, \
+    ExecutionMode
 from antlr4 import TerminalNode
 
 
@@ -209,7 +210,6 @@ class ParserVisitorTests(unittest.TestCase):
     @mock.patch.object(ParserVisitor, 'visit')
     @mock.patch('src.parser.parser_visitor.FunctionExpression')
     def test_visit_udf_function_call(self, func_mock, visit_mock):
-
         ctx = MagicMock()
         udf_name = 'name'
         func_args = [MagicMock(), MagicMock()]
@@ -218,6 +218,7 @@ class ParserVisitorTests(unittest.TestCase):
 
         def side_effect(arg):
             return values[arg]
+
         visit_mock.side_effect = side_effect
 
         visitor = ParserVisitor()
@@ -225,7 +226,8 @@ class ParserVisitorTests(unittest.TestCase):
         visit_mock.assert_has_calls(
             [call(ctx.simpleId()), call(ctx.functionArgs())])
 
-        func_mock.assert_called_with(None, name='name')
+        func_mock.assert_called_with(None, mode=ExecutionMode.EXEC,
+                                     name='name')
 
         for arg in func_args:
             func_mock.return_value.append_child.assert_any_call(arg)
@@ -256,9 +258,9 @@ class ParserVisitorTests(unittest.TestCase):
             RULE_createDefinitions
         ctx.children[3].getRuleIndex.return_value = evaql_parser.RULE_udfType
         ctx.children[4].getRuleIndex.return_value = evaql_parser.RULE_udfImpl
-        
+
         ctx.createDefinitions.return_value.__len__.return_value = 2
-        
+
         udf_name = 'name'
         udf_type = 'classification'
         udf_impl = MagicMock()
@@ -271,9 +273,9 @@ class ParserVisitorTests(unittest.TestCase):
 
         def side_effect(arg):
             return values[arg]
-        
+
         visit_mock.side_effect = side_effect
-        
+
         visitor = ParserVisitor()
         actual = visitor.visitCreateUdf(ctx)
 

--- a/test/udfs/test_fastrcnn_object_detector.py
+++ b/test/udfs/test_fastrcnn_object_detector.py
@@ -17,7 +17,7 @@ import unittest
 
 import cv2
 
-from src.models.storage.batch import FrameBatch
+from src.models.storage.batch import Batch
 from src.models.storage.frame import Frame
 from src.udfs.fastrcnn_object_detector import FastRCNNObjectDetector
 
@@ -40,7 +40,7 @@ class FastRCNNObjectDetectorTest(unittest.TestCase):
             os.path.join(self.base_path, 'data', 'dog.jpeg')), None)
         frame_dog_cat = Frame(1, self._load_image(
             os.path.join(self.base_path, 'data', 'dog_cat.jpg')), None)
-        frame_batch = FrameBatch([frame_dog, frame_dog_cat])
+        frame_batch = Batch([frame_dog, frame_dog_cat])
         detector = FastRCNNObjectDetector()
         result = detector.classify(frame_batch)
 

--- a/test/udfs/test_fastrcnn_object_detector.py
+++ b/test/udfs/test_fastrcnn_object_detector.py
@@ -40,7 +40,7 @@ class FastRCNNObjectDetectorTest(unittest.TestCase):
             os.path.join(self.base_path, 'data', 'dog.jpeg')), None)
         frame_dog_cat = Frame(1, self._load_image(
             os.path.join(self.base_path, 'data', 'dog_cat.jpg')), None)
-        frame_batch = FrameBatch([frame_dog, frame_dog_cat], None)
+        frame_batch = FrameBatch([frame_dog, frame_dog_cat])
         detector = FastRCNNObjectDetector()
         result = detector.classify(frame_batch)
 

--- a/test/util.py
+++ b/test/util.py
@@ -29,3 +29,18 @@ def create_dataframe_same(times=1):
         base_df = base_df.append(create_dataframe())
 
     return base_df
+
+def custom_list_of_dicts_equal(one, two):
+    for v1, v2 in zip(one, two):
+        if v1.keys() != v2.keys():
+            return False
+        for key in v1.keys():
+            if isinstance(v1[key], np.ndarray):
+                if not np.array_equal(v1[key], v2[key]):
+                    return False
+
+            else:
+                if v1[key] != v2[key]:
+                    return False
+
+    return True

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pandas as pd
+
+
+def create_dataframe(num_frames=1) -> pd.DataFrame:
+    frames = []
+    for i in range(1, num_frames + 1):
+        frames.append({"id": i, "data": (i * np.ones((1, 1)))})
+    return pd.DataFrame(frames)
+
+
+def create_dataframe_same(times=1):
+    base_df = create_dataframe()
+    for i in range(1, times):
+        base_df = base_df.append(create_dataframe())
+
+    return base_df


### PR DESCRIPTION
System Changes:
1. Make FrameBatch into a more generic data structure. The current implementation will store data as Pandas DataFrame. 
2. Define a new data structure for returning output from functions. This object again stores function output as pandas DataFrame. With this, we will be able to support functions with different outputs.
3. Update Plan Executor to return a Batch as output instead of a list of Batches.
4. Update UDFs, now every UDF will take as input a column vector instead of whole FrameBath. 
5. Add UDF binding utility, for integrating UDFs in SELECT queries. Also, added the catalog implementations to support this. 
6. Fix TupleValueExpression to deal with Batches instead of an 'unknown' list input type which was never supported by the system. 

------------------------------------------------
With these changes, we can now execute queries like:
SELECT FastRCNNObjectDetector(frame_data) FROM test WHERE FastRCNNObjectDetector(frame_data) = 'car' AND frame_id > 2; 

-------------------------------------------------

Refactoring:
FrameBatch is now called Batch as it supports any type of column.


