### PR TITLE
Java memory config

### DIFF
--- a/eva.yml
+++ b/eva.yml
@@ -9,7 +9,10 @@ executor:
 storage:
   engine: "src.storage.petastorm_storage_engine.PetastormStorageEngine"
 
-
+pyspark:
+  property: {'spark.logConf': 'true',
+             'spark.driver.memory': '1g',
+             'spark.sql.execution.arrow.pyspark.enabled': 'true'}
 
 server:
   host: "0.0.0.0"

--- a/script/test/cleanup.sh
+++ b/script/test/cleanup.sh
@@ -3,5 +3,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rm -rf $DIR/../../eva_datasets
 
-mysql -e 'Drop DATABASE eva_catalog;'
-mysql -e 'CREATE DATABASE IF NOT EXISTS eva_catalog;'
+mysql -u root -e 'Drop DATABASE eva_catalog;'
+mysql -u root -e 'CREATE DATABASE IF NOT EXISTS eva_catalog;'

--- a/src/spark/session.py
+++ b/src/spark/session.py
@@ -35,8 +35,8 @@ class Session(object):
         return cls._instance
 
     def __init__(self):
-        config = ConfigurationManager()
-        name = config.get_value('core', 'application')
+        self._config = ConfigurationManager()
+        name = self._config.get_value('core', 'application')
         self.init_spark_session(name)
 
     def init_spark_session(self, application_name, spark_master=None):
@@ -49,13 +49,11 @@ class Session(object):
 
         :return: spark_session: A spark session
         """
+
         eva_spark_conf = SparkConf()
-        eva_spark_conf.set('spark.logConf', 'true')
-        # enable Arrow optimization for spark Session
-        # This is added to help with to and fro conversion
-        # between pandas and spark dataframe
-        # https://docs.databricks.com/spark/latest/spark-sql/spark-pandas.html
-        eva_spark_conf.set('spark.sql.execution.arrow.pyspark.enabled', 'true')
+        pyspark_config = self._config.get_value('pyspark', 'property') 
+        for key, value in pyspark_config.items():
+            eva_spark_conf.set(key, value)
 
         session_builder = SparkSession \
             .builder \

--- a/test/integration_tests/test_select_executor.py
+++ b/test/integration_tests/test_select_executor.py
@@ -60,7 +60,7 @@ class SelectExecutorTest(unittest.TestCase):
         expected_batch = list(create_dummy_batches())
         self.assertEqual([actual_batch], expected_batch)
 
-    @unittest.skip('Too slow when batch size is small')
+    @unittest.skip('Too slow when batch size is small.')
     def test_should_load_and_select_real_video_in_table(self):
         query = """LOAD DATA INFILE 'data/ua_detrac/ua_detrac.mp4'
                    INTO MyVideo;"""


### PR DESCRIPTION
- Move all pyspark config to eva.yml
- Add java memory config.

Tested when spark.driver.memory is 4g, batch size 100 works. 
For local testing and travis, keep the default value of spark.driver.memory as 1g, where batch size 50 works. 