### PR TITLE
Client server

### DIFF
--- a/eva.py
+++ b/eva.py
@@ -30,9 +30,9 @@ def eva():
 
     # Get the hostname and port information from the configuration file
     config = ConfigurationManager()
-    hostname = config.get_value('server', 'hostname')
+    hostname = config.get_value('server', 'host')
     port = config.get_value('server', 'port')
-    socket_timeout = config.get_value('server', 'socket_timeout')    
+    socket_timeout = config.get_value('server', 'socket_timeout')
     loop = asyncio.new_event_loop()
     stop_server_future = loop.create_future()
 

--- a/eva.yml
+++ b/eva.yml
@@ -1,6 +1,6 @@
 core:
   location: "eva_datasets"
-  sqlalchemy_database_uri: 'mysql+pymysql://root:root@localhost/eva_catalog'
+  sqlalchemy_database_uri: 'mysql+pymysql://root@localhost/eva_catalog'
   application: "eva"
 
 executor:

--- a/eva.yml
+++ b/eva.yml
@@ -1,6 +1,6 @@
 core:
   location: "eva_datasets"
-  sqlalchemy_database_uri: 'mysql+pymysql://root@localhost/eva_catalog'
+  sqlalchemy_database_uri: 'mysql+pymysql://root:root@localhost/eva_catalog'
   application: "eva"
 
 executor:

--- a/eva_client.py
+++ b/eva_client.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from src.server.client import EvaClient, start_client
+
+from src.configuration.configuration_manager import ConfigurationManager
+
+from src.utils.logging_manager import LoggingManager
+from src.utils.logging_manager import LoggingLevel
+
+
+def eva_client():
+    """
+        Start the eva system
+    """
+
+    # Get the hostname and port information from the configuration file
+    config = ConfigurationManager()
+    hostname = config.get_value('server', 'host')
+    port = config.get_value('server', 'port')
+
+    # Launch server
+    try:
+        asyncio.run(start_client(factory=lambda: EvaClient(),
+                                 host=hostname,
+                                 port=port,
+                                 max_retry_count=3)
+                    )
+
+    except Exception as e:
+        LoggingManager().log(e, LoggingLevel.CRITICAL)
+
+
+if __name__ == '__main__':
+    # execute only if run as the entry point into the program
+    eva_client()

--- a/src/models/server/response.py
+++ b/src/models/server/response.py
@@ -1,0 +1,66 @@
+import json
+import pandas as pd
+
+from enum import Enum
+from src.models.storage.batch import Batch
+
+
+class ResponseStatus(str, Enum):
+    FAIL = -1
+    SUCCESS = 0
+
+
+class ResponseEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Batch):
+            return {"__batch__": obj.to_json()}
+        return json.JSONEncoder.default(self, obj)
+
+
+def as_response(d):
+    if "__batch__" in d:
+        return Batch.from_json(d["__batch__"])
+    else:
+        return d
+
+
+class Response:
+    """
+    Data model for EVA server response
+    """
+
+    def __init__(self, status: ResponseStatus, batch: Batch, metrics=None):
+        self._status = status
+        self._batch = batch
+        self._metrics = metrics
+
+    def to_json(self):
+        obj = {'status': self.status,
+               'batch': self.batch,
+               'metrics': self.metrics}
+        return json.dumps(obj, cls=ResponseEncoder)
+
+    @classmethod
+    def from_json(cls, json_str: str):
+        obj = json.loads(json_str, object_hook=as_response)
+        return cls(**obj)
+
+    def __eq__(self, other: 'Response'):
+        return self.status == other.status and \
+            self.batch == other.batch and \
+            self.metrics == other.metrics
+
+    def __str__(self):
+        return self.to_json(indent=2)
+
+    @property
+    def status(self):
+        return self._status
+
+    @property
+    def batch(self):
+        return self._batch
+
+    @property
+    def metrics(self):
+        return self._metrics

--- a/src/models/server/response.py
+++ b/src/models/server/response.py
@@ -1,5 +1,4 @@
 import json
-import pandas as pd
 
 from enum import Enum
 from src.models.storage.batch import Batch
@@ -51,7 +50,11 @@ class Response:
             self.metrics == other.metrics
 
     def __str__(self):
-        return self.to_json(indent=2)
+        return 'Response Object:\n' \
+               '@status: %s\n' \
+               '@batch: %s\n' \
+               '@metrics: %s' \
+               % (self.status, self.batch, self.metrics)
 
     @property
     def status(self):

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -21,17 +21,20 @@ from pandas import DataFrame
 from src.models.inference.outcome import Outcome
 from src.utils.logging_manager import LoggingManager, LoggingLevel
 
+
 class BatchEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, pd.DataFrame):
             return {"__dataframe__": obj.to_json()}
         return json.JSONEncoder.default(self, obj)
 
+
 def as_batch(d):
     if "__dataframe__" in d:
         return pd.read_json(d["__dataframe__"])
     else:
         return d
+
 
 class Batch:
     """
@@ -100,7 +103,14 @@ class Batch:
                    identifier_column=obj['identifier_column'])
 
     def __str__(self):
-        return self.to_json()
+        """
+        For debug propose
+        """
+        return 'Batch Object:\n' \
+               '@dataframe: %s\n' \
+               '@batch_size: %d\n' \
+               '@identifier_column: %s' \
+               % (self._frames, self._batch_size, self.identifier_column)
 
     def __eq__(self, other: 'Batch'):
         return self.frames.equals(other.frames) and \

--- a/src/models/storage/batch.py
+++ b/src/models/storage/batch.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import numpy as np
 import pandas as pd
 
@@ -20,6 +21,17 @@ from pandas import DataFrame
 from src.models.inference.outcome import Outcome
 from src.utils.logging_manager import LoggingManager, LoggingLevel
 
+class BatchEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, pd.DataFrame):
+            return {"__dataframe__": obj.to_json()}
+        return json.JSONEncoder.default(self, obj)
+
+def as_batch(d):
+    if "__dataframe__" in d:
+        return pd.read_json(d["__dataframe__"])
+    else:
+        return d
 
 class Batch:
     """
@@ -75,18 +87,20 @@ class Batch:
     def column_as_numpy_array(self, column_name='data'):
         return np.array(self._frames[column_name])
 
+    def to_json(self):
+        obj = {'frames': self.frames,
+               'batch_size': self.batch_size,
+               'identifier_column': self.identifier_column}
+        return json.dumps(obj, cls=BatchEncoder)
+
+    @classmethod
+    def from_json(cls, json_str: str):
+        obj = json.loads(json_str, object_hook=as_batch)
+        return cls(frames=obj['frames'],
+                   identifier_column=obj['identifier_column'])
+
     def __str__(self):
-        """
-        For debug propose
-        """
-        return 'Batch Object:\n' \
-               '@dataframe: %s\n' \
-               '@batch_size: %d\n' \
-               '@outcome: %s\n' \
-               '@temp_outcome: %s\n' \
-               '@identifier_column: %s\n' \
-               % (self._frames, self._batch_size, self._outcomes,
-                  self._temp_outcomes, self.identifier_column)
+        return self.to_json()
 
     def __eq__(self, other: 'Batch'):
         return self.frames.equals(other.frames) and \

--- a/src/server/client.py
+++ b/src/server/client.py
@@ -43,7 +43,7 @@ class EvaClient(asyncio.Protocol):
     __errors__ = 0
 
     # Store response from server
-    _response_chunk = None
+    _response_chunks = []
 
     def __init__(self):
         self.done = asyncio.Future()
@@ -98,7 +98,7 @@ class EvaClient(asyncio.Protocol):
                              str(response_chunk) + "|--"
                              )
 
-        self._response_chunk = response_chunk
+        self._response_chunks.append(response_chunk)
 
     def send_message(self, message):
 

--- a/src/server/command_handler.py
+++ b/src/server/command_handler.py
@@ -19,6 +19,7 @@ from src.parser.parser import Parser
 from src.optimizer.statement_to_opr_convertor import StatementToPlanConvertor
 from src.optimizer.plan_generator import PlanGenerator
 from src.executor.plan_executor import PlanExecutor
+from src.models.server.response import ResponseStatus, Response
 
 from src.utils.logging_manager import LoggingManager, LoggingLevel
 
@@ -34,6 +35,7 @@ def handle_request(transport, request_message):
     LoggingManager().log('Receive request: --|' + str(request_message) + '|--')
 
     output_batch = None
+    response = None
     try:
         stmt = Parser().parse(request_message)[0]
         l_plan = StatementToPlanConvertor().visit(stmt)
@@ -41,18 +43,20 @@ def handle_request(transport, request_message):
         output_batch = PlanExecutor(p_plan).execute_plan()
     except Exception as e:
         LoggingManager().log(e, LoggingLevel.WARNING)
-        output_batch = 'Fail\n'
+        response = Response(status=ResponseStatus.FAIL, batch=None)
 
-    if output_batch is None:
-        response_message = 'Success\n'
-    else:
-        response_message = str(output_batch)
+    if response is None:
+        response = Response(status=ResponseStatus.SUCCESS,
+                            batch=output_batch)
+
+    responseData = response.to_json()
+    # Send data length, because response can be very large
+    data = (str(len(responseData)) + '|' + responseData).encode('ascii')
 
     LoggingManager().log('Response to client: --|' +
-                         str(response_message) +
-                         '|--')
+                         str(response) + '|--\n' +
+                         'Length: ' + str(len(responseData)))
 
-    data = response_message.encode('ascii')
     transport.write(data)
 
-    return response_message
+    return response

--- a/src/server/command_handler.py
+++ b/src/server/command_handler.py
@@ -38,7 +38,7 @@ def handle_request(transport, request_message):
         stmt = Parser().parse(request_message)[0]
         l_plan = StatementToPlanConvertor().visit(stmt)
         p_plan = PlanGenerator().build(l_plan)
-        output_batch = PlanExecutor().execute_plan()
+        output_batch = PlanExecutor(p_plan).execute_plan()
     except Exception as e:
         LoggingManager().log(e, LoggingLevel.WARNING)
         output_batch = 'Fail\n'

--- a/src/server/interpreter.py
+++ b/src/server/interpreter.py
@@ -56,16 +56,16 @@ class EvaCommandInterpreter(Cmd):
         self._server_result = segs[1]
         next_chunk = 1
         while len(self._server_result) < result_length:
-            print('Total length: %d, Received: %d' %
-                  (result_length, len(self._server_result)), end='\r')
+            #print('Total length: %d, Received: %d' %
+            #      (result_length, len(self._server_result)), end='\r')
             # next chunk is not avaiable yet
             while len(self._protocol._response_chunks) <= next_chunk:
                 _ = 1
             self._server_result += self._protocol._response_chunks[next_chunk]
             next_chunk += 1
 
-        print('Total length: %d, Received: %d' %
-              (result_length, len(self._server_result)))
+        #print('Total length: %d, Received: %d' %
+        #      (result_length, len(self._server_result)))
         response = Response.from_json(self._server_result)
         print(response)
         return False

--- a/src/server/interpreter.py
+++ b/src/server/interpreter.py
@@ -56,7 +56,7 @@ class EvaCommandInterpreter(Cmd):
         self._server_result = segs[1]
         next_chunk = 1
         while len(self._server_result) < result_length:
-            #print('Total length: %d, Received: %d' %
+            # print('Total length: %d, Received: %d' %
             #      (result_length, len(self._server_result)), end='\r')
             # next chunk is not avaiable yet
             while len(self._protocol._response_chunks) <= next_chunk:
@@ -64,7 +64,7 @@ class EvaCommandInterpreter(Cmd):
             self._server_result += self._protocol._response_chunks[next_chunk]
             next_chunk += 1
 
-        #print('Total length: %d, Received: %d' %
+        # print('Total length: %d, Received: %d' %
         #      (result_length, len(self._server_result)))
         response = Response.from_json(self._server_result)
         print(response)

--- a/src/server/interpreter.py
+++ b/src/server/interpreter.py
@@ -13,84 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
-import glob
-
-from PIL import Image
 from cmd import Cmd
-
-from src.parser.parser import Parser
 
 
 class EvaCommandInterpreter(Cmd):
 
     # Store results from server
     _server_result = None
+    _url = None
+
+    def __init__(self):
+        super().__init__()
 
     def set_protocol(self, protocol):
-        self.protocol = protocol
+        self._protocol = protocol
 
     def do_greet(self, line):
         print("greeting")
 
+    def emptyline(self):
+        print("Enter a valid query.")
+        return False
+
     def onecmd(self, s):
-
-        cmd_result = Cmd.onecmd(self, s)
-
-        # Send request to server
-        self.protocol.send_message(s)
-        _server_result = self.protocol._response_chunk
-
-        if _server_result is not None:
-            print(_server_result)
-        _server_result = None
-
-        return cmd_result
+        if s == "":
+            return self.emptyline()
+        elif (s == "exit" or s == "EXIT"):
+            return SystemExit
+        else:
+            return self.do_query(s)
 
     def do_query(self, query):
         """Takes in SQL query and generates the output"""
 
-        # Type exit to stop program
-        if(query == "exit" or query == "EXIT"):
-            raise SystemExit
-
-        if len(query) == 0:
-            print("Empty query")
-
-        else:
-            try:
-                # Connect and Query from Eva
-                parser = Parser()
-                eva_statement = parser.parse(query)
-                select_stmt = eva_statement[0]
-                print("Result from the parser:")
-                print(select_stmt)
-                print('\n')
-
-                # Read Input Videos
-                # Replace with Input Pipeline once finished
-                input_video = []
-                for filename in glob.glob('data/sample_video/*.jpg'):
-                    im = Image.open(filename)
-                    # to handle 'too many open files' error
-                    im_copy = im.copy()
-                    input_video.append(im_copy)
-                    im.close()
-
-                # Write Output to final folder
-                # Replace with output pipeline once finished
-                ouput_frames = random.sample(input_video, 50)
-                output_folder = "data/sample_output/"
-
-                for i in range(len(ouput_frames)):
-                    frame_name = output_folder + "output" + str(i) + ".jpg"
-                    ouput_frames[i].save(frame_name)
-
-                print("Refer pop-up for a sample of the output")
-                ouput_frames[0].show()
-
-            except TypeError:
-                print("SQL Statement improperly formatted. Try again.")
+        self._protocol._response_chunk = None
+        self._protocol.send_message(query)
+        while self._protocol._response_chunk is None:
+            _ = 1
+        self._server_result = self._protocol._response_chunk
+        print(self._server_result)
+        return False
 
     def do_quit(self, args):
         """Quits the program."""

--- a/test/models/server/test_response.py
+++ b/test/models/server/test_response.py
@@ -21,12 +21,6 @@ from test.util import create_dataframe
 
 class ResponseTest(unittest.TestCase):
 
-    def test_server_response_to_json_string(self):
-        batch = Batch(frames=create_dataframe())
-        response = Response(status=ResponseStatus.SUCCESS,
-                            batch=batch)
-        print(response.to_json())
-
     def test_server_reponse_from_json_string(self):
         batch = Batch(frames=create_dataframe())
         response = Response(status=ResponseStatus.SUCCESS,

--- a/test/models/server/test_response.py
+++ b/test/models/server/test_response.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from src.models.storage.batch import Batch
+from src.models.server.response import ResponseStatus, Response
+from test.util import create_dataframe
+
+
+class ResponseTest(unittest.TestCase):
+
+    def test_server_response_to_json_string(self):
+        batch = Batch(frames=create_dataframe())
+        response = Response(status=ResponseStatus.SUCCESS,
+                            batch=batch)
+        print(response.to_json())
+
+    def test_server_reponse_from_json_string(self):
+        batch = Batch(frames=create_dataframe())
+        response = Response(status=ResponseStatus.SUCCESS,
+                            batch=batch)
+        response2 = Response.from_json(response.to_json())
+        self.assertEqual(response, response2)
+
+
+
+

--- a/test/models/storage/test_batch.py
+++ b/test/models/storage/test_batch.py
@@ -23,6 +23,17 @@ from test.util import create_dataframe_same, create_dataframe
 
 class BatchTest(unittest.TestCase):
 
+    def test_batch_to_json(self):
+        batch = Batch(frames=create_dataframe(),
+                      identifier_column='id')
+        print(batch.to_json())
+
+    def test_batch_from_json(self):
+        batch = Batch(frames=create_dataframe(),
+                      identifier_column='id')
+        batch2 = Batch.from_json(batch.to_json())
+        self.assertEqual(batch, batch2)
+
     def test_set_outcomes_method_should_set_the_predictions_with_udf_name(
             self):
         batch = Batch(frames=create_dataframe())

--- a/test/models/storage/test_batch.py
+++ b/test/models/storage/test_batch.py
@@ -23,11 +23,6 @@ from test.util import create_dataframe_same, create_dataframe
 
 class BatchTest(unittest.TestCase):
 
-    def test_batch_to_json(self):
-        batch = Batch(frames=create_dataframe(),
-                      identifier_column='id')
-        print(batch.to_json())
-
     def test_batch_from_json(self):
         batch = Batch(frames=create_dataframe(),
                       identifier_column='id')


### PR DESCRIPTION
Add client-server support, replace the original pr #102 

Example Usage:
Launch EVA database Server: `python eva.py`

Launch CLI: `python eva_client.py` 

Two queries below will take a while.
`LOAD DATA INFILE 'data/ua_detrac/ua_detrac.mp4' INTO MyVideo;`
`SELECT id, data FROM MyVideo WHERE id < 5;`