### PR TITLE
Limit Implementation

### DIFF
--- a/src/executor/limit_executor.py
+++ b/src/executor/limit_executor.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Iterator
+
+from src.models.storage.batch import Batch
+from src.executor.abstract_executor import AbstractExecutor
+from src.planner.limit_plan import LimitPlan
+from src.utils.logging_manager import LoggingManager, LoggingLevel
+
+
+class LimitExecutor(AbstractExecutor):
+    """
+    Limits the number of rows returned
+
+    Arguments:
+        node (AbstractPlan): The Limit Plan
+
+    """
+
+    def __init__(self, node: LimitPlan):
+        super().__init__(node)
+        self._limit_count = node.limit_value
+        self.BATCH_MAX_SIZE = 50  # from eva.yml
+
+    def validate(self):
+        pass
+
+    def exec(self) -> Iterator[Batch]:
+        child_executor = self.children[0]
+        aggregated_batch_list = []
+
+        # aggregates the batches into one large batch
+        for batch in child_executor.exec():
+            aggregated_batch_list.append(batch)
+        aggregated_batch = Batch.concat(aggregated_batch_list, copy=False)
+
+        aggregated_frame = aggregated_batch.frames
+
+        # limits the rows
+        if self._limit_count <= aggregated_frame.shape[0]:
+            aggregated_frame = aggregated_frame.iloc[:self._limit_count]
+        else:
+            LoggingManager().log('Limit value greater than \
+                    current size of data!', LoggingLevel.WARNING)
+
+        # split the aggregated batch into smaller ones based
+        #  on self.BATCH_MAX_SIZE
+        for i in range(0, aggregated_frame.shape[0], self.BATCH_MAX_SIZE):
+            bound = i + self.BATCH_MAX_SIZE
+            if bound > aggregated_frame.shape[0]:
+                bound = aggregated_frame.shape[0]
+            batch = Batch(frames=aggregated_frame.iloc[i: bound])
+            batch.reset_index()
+            yield batch

--- a/src/executor/plan_executor.py
+++ b/src/executor/plan_executor.py
@@ -15,6 +15,7 @@
 import pandas as pd
 
 from src.executor.abstract_executor import AbstractExecutor
+from src.executor.limit_executor import LimitExecutor
 from src.executor.seq_scan_executor import SequentialScanExecutor
 from src.models.storage.batch import Batch
 from src.planner.abstract_plan import AbstractPlan
@@ -76,6 +77,8 @@ class PlanExecutor:
             executor_node = LoadDataExecutor(node=plan)
         elif plan_node_type == PlanNodeType.ORDER_BY:
             executor_node = OrderByExecutor(node=plan)
+        elif plan_node_type == PlanNodeType.LIMIT:
+            executor_node = LimitExecutor(node=plan)
 
         # Build Executor Tree for children
         for children in plan.children:

--- a/src/optimizer/generators/seq_scan_generator.py
+++ b/src/optimizer/generators/seq_scan_generator.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 from src.optimizer.generators.base import Generator
 from src.optimizer.operators import LogicalGet, Operator, LogicalFilter, \
-    LogicalProject, LogicalUnion, LogicalOrderBy
+    LogicalProject, LogicalUnion, LogicalOrderBy, LogicalLimit
 from src.planner.seq_scan_plan import SeqScanPlan
 from src.planner.union_plan import UnionPlan
 from src.planner.storage_plan import StoragePlan
 from src.planner.orderby_plan import OrderByPlan
+from src.planner.limit_plan import LimitPlan
 
 
 class ScanGenerator(Generator):
@@ -53,6 +54,11 @@ class ScanGenerator(Generator):
         orderbyplan.append_child(self._plan)
         self._plan = orderbyplan
 
+    def _visit_logical_limit(self, operator: LogicalLimit):
+        limitplan = LimitPlan(operator.limit_count)
+        limitplan.append_child(self._plan)
+        self._plan = limitplan
+
     def _visit(self, operator: Operator):
         if isinstance(operator, LogicalUnion):
             self._visit_logical_union(operator)
@@ -63,6 +69,9 @@ class ScanGenerator(Generator):
 
         if isinstance(operator, LogicalOrderBy):
             self._visit_logical_orderby(operator)
+
+        if isinstance(operator, LogicalLimit):
+            self._visit_logical_limit(operator)
 
         if isinstance(operator, LogicalGet):
             self._visit_logical_get(operator)

--- a/src/optimizer/operators.py
+++ b/src/optimizer/operators.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from enum import IntEnum, unique
+from enum import IntEnum, unique, auto
 from typing import List
 
 from src.catalog.models.df_metadata import DataFrameMetadata
@@ -29,17 +29,17 @@ class OperatorType(IntEnum):
     """
     Manages enums for all the operators supported
     """
-    LOGICALGET = 1,
-    LOGICALFILTER = 2,
-    LOGICALPROJECT = 3,
-    LOGICALINSERT = 4,
-    LOGICALCREATE = 5,
-    LOGICALCREATEUDF = 6,
-    LOGICALLOADDATA = 7,
-    LOGICALQUERYDERIVEDGET = 8,
-    LOGICALUNION = 9,
-    LOGICALORDERBY = 10
-    LOGICALLIMIT = 11
+    LOGICALGET = auto()
+    LOGICALFILTER = auto()
+    LOGICALPROJECT = auto()
+    LOGICALINSERT = auto()
+    LOGICALCREATE = auto()
+    LOGICALCREATEUDF = auto()
+    LOGICALLOADDATA = auto()
+    LOGICALQUERYDERIVEDGET = auto()
+    LOGICALUNION = auto()
+    LOGICALORDERBY = auto()
+    LOGICALLIMIT = auto()
 
 
 class Operator:

--- a/src/optimizer/operators.py
+++ b/src/optimizer/operators.py
@@ -16,6 +16,7 @@ from enum import IntEnum, unique
 from typing import List
 
 from src.catalog.models.df_metadata import DataFrameMetadata
+from src.expression.constant_value_expression import ConstantValueExpression
 from src.parser.table_ref import TableRef
 from src.expression.abstract_expression import AbstractExpression
 from src.catalog.models.df_column import DataFrameColumn
@@ -38,6 +39,7 @@ class OperatorType(IntEnum):
     LOGICALQUERYDERIVEDGET = 8,
     LOGICALUNION = 9,
     LOGICALORDERBY = 10
+    LOGICALLIMIT = 11
 
 
 class Operator:
@@ -165,6 +167,24 @@ class LogicalOrderBy(Operator):
             return False
         return (is_subtree_equal
                 and self.orderby_list == other.orderby_list)
+
+
+class LogicalLimit(Operator):
+    def __init__(self, limit_count: ConstantValueExpression,
+                 children: List = None):
+        super().__init__(OperatorType.LOGICALLIMIT, children)
+        self._limit_count = limit_count
+
+    @property
+    def limit_count(self):
+        return self._limit_count
+
+    def __eq__(self, other):
+        is_subtree_equal = super().__eq__(other)
+        if not isinstance(other, LogicalLimit):
+            return False
+        return (is_subtree_equal
+                and self.limit_count == other.limit_count)
 
 
 class LogicalUnion(Operator):

--- a/src/optimizer/plan_generator.py
+++ b/src/optimizer/plan_generator.py
@@ -28,7 +28,7 @@ class PlanGenerator:
     """
     _SCAN_NODE_TYPES = (OperatorType.LOGICALFILTER, OperatorType.LOGICALGET,
                         OperatorType.LOGICALPROJECT, OperatorType.LOGICALUNION,
-                        OperatorType.LOGICALORDERBY)
+                        OperatorType.LOGICALORDERBY, OperatorType.LOGICALLIMIT)
     _INSERT_NODE_TYPE = OperatorType.LOGICALINSERT
     _CREATE_NODE_TYPE = OperatorType.LOGICALCREATE
     _CREATE_UDF_NODE_TYPE = OperatorType.LOGICALCREATEUDF

--- a/src/optimizer/statement_to_opr_convertor.py
+++ b/src/optimizer/statement_to_opr_convertor.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.expression.abstract_expression import AbstractExpression
-from src.expression.constant_value_expression import ConstantValueExpression
 from src.optimizer.operators import (LogicalGet, LogicalFilter, LogicalProject,
                                      LogicalInsert, LogicalCreate,
                                      LogicalCreateUDF, LogicalLoadData,
@@ -113,7 +112,7 @@ class StatementToPlanConvertor:
         self._plan = orderby_opr
 
     def _visit_limit(self, limit_count):
-        limit_opr = LogicalLimit(ConstantValueExpression(limit_count))
+        limit_opr = LogicalLimit(limit_count)
         limit_opr.append_child(self._plan)
         self._plan = limit_opr
 

--- a/src/parser/parser_visitor.py
+++ b/src/parser/parser_visitor.py
@@ -338,6 +338,7 @@ class ParserVisitor(evaql_parserVisitor):
         from_clause = None
         where_clause = None
         orderby_clause = None
+        limit_count = None
 
         # first child will be a SELECT terminal token
 
@@ -355,6 +356,9 @@ class ParserVisitor(evaql_parserVisitor):
                 elif rule_idx == evaql_parser.RULE_orderByClause:
                     orderby_clause = self.visit(ctx.orderByClause())
 
+                elif rule_idx == evaql_parser.RULE_limitClause:
+                    limit_count = self.visit(ctx.limitClause())
+
             except BaseException:
                 # stop parsing something bad happened
                 return None
@@ -365,7 +369,8 @@ class ParserVisitor(evaql_parserVisitor):
 
         select_stmt = SelectStatement(
             target_list, from_clause, where_clause,
-            orderby_clause_list=orderby_clause)
+            orderby_clause_list=orderby_clause,
+            limit_count=limit_count)
 
         return select_stmt
 
@@ -406,6 +411,9 @@ class ParserVisitor(evaql_parserVisitor):
             sort_token = ParserOrderBySortType.ASC
 
         return self.visitChildren(ctx.expression()), sort_token
+
+    def visitLimitClause(self, ctx: evaql_parser.LimitClauseContext):
+        return self.visitChildren(ctx)
 
     ##################################################################
     # LOAD STATEMENT

--- a/src/parser/parser_visitor.py
+++ b/src/parser/parser_visitor.py
@@ -413,7 +413,7 @@ class ParserVisitor(evaql_parserVisitor):
         return self.visitChildren(ctx.expression()), sort_token
 
     def visitLimitClause(self, ctx: evaql_parser.LimitClauseContext):
-        return self.visitChildren(ctx)
+        return ConstantValueExpression(self.visitChildren(ctx))
 
     ##################################################################
     # LOAD STATEMENT

--- a/src/parser/select_statement.py
+++ b/src/parser/select_statement.py
@@ -17,6 +17,7 @@ from src.parser.statement import AbstractStatement
 
 from src.parser.types import StatementType
 from src.expression.abstract_expression import AbstractExpression
+from src.expression.constant_value_expression import ConstantValueExpression
 from src.parser.table_ref import TableRef
 from typing import List
 
@@ -105,7 +106,7 @@ class SelectStatement(AbstractStatement):
         return self._limit_count
 
     @limit_count.setter
-    def limit_count(self, limit_count_new):
+    def limit_count(self, limit_count_new: ConstantValueExpression):
         self._limit_count = limit_count_new
 
     def __str__(self) -> str:

--- a/src/parser/select_statement.py
+++ b/src/parser/select_statement.py
@@ -49,6 +49,7 @@ class SelectStatement(AbstractStatement):
         self._union_link = None
         self._union_all = False
         self._orderby_list = kwargs.get("orderby_clause_list", None)
+        self._limit_count = kwargs.get("limit_count", None)
 
     @property
     def union_link(self):
@@ -99,6 +100,14 @@ class SelectStatement(AbstractStatement):
         # orderby_list_new: List[(TupleValueExpression, int)]
         self._orderby_list = orderby_list_new
 
+    @property
+    def limit_count(self):
+        return self._limit_count
+
+    @limit_count.setter
+    def limit_count(self, limit_count_new):
+        self._limit_count = limit_count_new
+
     def __str__(self) -> str:
         print_str = "SELECT {} FROM {} WHERE {}".format(self._target_list,
                                                         self._from_table,
@@ -112,6 +121,9 @@ class SelectStatement(AbstractStatement):
         if self._orderby_list is not None:
             print_str += " ORDER BY " + str(self._orderby_list)
 
+        if self._limit_count is not None:
+            print_str += " LIMIT " + str(self._limit_count)
+
         return print_str
 
     def __eq__(self, other):
@@ -122,4 +134,5 @@ class SelectStatement(AbstractStatement):
                 and self.where_clause == other.where_clause
                 and self.union_link == other.union_link
                 and self.union_all == other.union_all
-                and self.orderby_list == other.orderby_list)
+                and self.orderby_list == other.orderby_list
+                and self.limit_count == other.limit_count)

--- a/src/planner/limit_plan.py
+++ b/src/planner/limit_plan.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.planner.abstract_plan import AbstractPlan
+from src.planner.types import PlanNodeType
+from src.expression.constant_value_expression import ConstantValueExpression
+
+
+class LimitPlan(AbstractPlan):
+    """
+    This plan is used for storing information required for limit
+    operations.
+
+    Arguments:
+        limit_count: ConstantValueExpression
+            A ConstantValueExpression which is the count of the
+            number of rows returned
+    """
+
+    def __init__(self, limit_count: ConstantValueExpression):
+        self._limit_count = limit_count
+        super().__init__(PlanNodeType.LIMIT)
+
+    @property
+    def limit_expression(self):
+        return self._limit_count
+
+    @property
+    def limit_value(self):
+        return self._limit_count.value

--- a/src/planner/types.py
+++ b/src/planner/types.py
@@ -26,4 +26,5 @@ class PlanNodeType(IntEnum):
     LOAD_DATA = 7
     UNION = 8
     ORDER_BY = 9
+    LIMIT = 10
     # add other types

--- a/test/executor/test_limit_executor.py
+++ b/test/executor/test_limit_executor.py
@@ -107,6 +107,8 @@ class LimitExecutorTest(unittest.TestCase):
         limit_executor.append_child(DummyExecutor(sorted_batches))
         reduced_batches = list(limit_executor.exec())
 
+        # merge everything into one batch
+        aggregated_batch = Batch.concat(reduced_batches, copy=False)
         """
            A  B   C
         0  1  5   6
@@ -118,4 +120,4 @@ class LimitExecutorTest(unittest.TestCase):
 
         expected_batches = [Batch(frames=df) for df in [expected_df1]]
 
-        self.assertEqual(expected_batches[0], reduced_batches[0])
+        self.assertEqual(expected_batches[0], aggregated_batch)

--- a/test/executor/test_limit_executor.py
+++ b/test/executor/test_limit_executor.py
@@ -1,0 +1,121 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from src.executor.orderby_executor import OrderByExecutor
+from src.executor.limit_executor import LimitExecutor
+from src.expression.tuple_value_expression import TupleValueExpression
+from src.models.storage.batch import Batch
+from src.parser.types import ParserOrderBySortType
+from test.executor.utils import DummyExecutor
+from src.planner.orderby_plan import OrderByPlan
+from src.planner.limit_plan import LimitPlan
+from src.expression.constant_value_expression import ConstantValueExpression
+
+
+class LimitExecutorTest(unittest.TestCase):
+
+    def test_should_return_smaller_num_rows(self):
+        dfs = [pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
+                            columns=list('ABCD')) for _ in range(4)]
+
+        batches = [Batch(frames=df) for df in dfs]
+
+        limit_value = 125
+
+        plan = LimitPlan(ConstantValueExpression(limit_value))
+
+        limit_executor = LimitExecutor(plan)
+        limit_executor.append_child(DummyExecutor(batches))
+        reduced_batches = list(limit_executor.exec())
+
+        total_size = 0
+        for batch in reduced_batches:
+            total_size += batch.batch_size
+
+        self.assertEqual(total_size, limit_value)
+
+    def test_should_return_limit_greater_than_size(self):
+        """ This should return the exact same data
+        if the limit value is greater than what is present.
+        This will also leave a warning """
+
+        dfs = [pd.DataFrame(np.random.randint(0, 100, size=(100, 4)),
+                            columns=list('ABCD')) for _ in range(4)]
+
+        batches = [Batch(frames=df) for df in dfs]
+
+        previous_total_size = 0
+        for batch in batches:
+            previous_total_size += batch.batch_size
+
+        limit_value = 500
+
+        plan = LimitPlan(ConstantValueExpression(limit_value))
+
+        limit_executor = LimitExecutor(plan)
+        limit_executor.append_child(DummyExecutor(batches))
+        reduced_batches = list(limit_executor.exec())
+
+        after_total_size = 0
+        for batch in reduced_batches:
+            after_total_size += batch.batch_size
+
+        self.assertEqual(previous_total_size, after_total_size)
+
+    def test_should_return_top_frames_after_sorting(self):
+        """
+        Checks if limit returns the top 2 rows from the data
+        after sorting
+
+        data (3 batches):
+        'A' 'B' 'C'
+        [1, 1, 1]
+        ----------
+        [1, 5, 6]
+        [4, 7, 10]
+        ----------
+        [2, 9, 7]
+        [4, 1, 2]
+        [4, 2, 4]
+        """
+
+        df1 = pd.DataFrame(
+            np.array([[1, 1, 1]]), columns=['A', 'B', 'C'])
+        df2 = pd.DataFrame(
+            np.array([[1, 5, 6], [4, 7, 10]]), columns=['A', 'B', 'C'])
+        df3 = pd.DataFrame(
+            np.array([[2, 9, 7], [4, 1, 2],
+                      [4, 2, 4]]), columns=['A', 'B', 'C'])
+
+        batches = [Batch(frames=df) for df in [df1, df2, df3]]
+
+        "query: .... ORDER BY A ASC, B DESC limit 2"
+
+        plan = OrderByPlan(
+            [(TupleValueExpression('A'), ParserOrderBySortType.ASC),
+             (TupleValueExpression('B'), ParserOrderBySortType.DESC)])
+
+        orderby_executor = OrderByExecutor(plan)
+        orderby_executor.append_child(DummyExecutor(batches))
+
+        sorted_batches = list(orderby_executor.exec())
+
+        limit_value = 2
+        plan = LimitPlan(ConstantValueExpression(limit_value))
+        limit_executor = LimitExecutor(plan)
+        limit_executor.append_child(DummyExecutor(sorted_batches))
+        reduced_batches = list(limit_executor.exec())
+
+        """
+           A  B   C
+        0  1  5   6
+        1  1  1   1
+        """
+
+        expected_df1 = pd.DataFrame(
+            np.array([[1, 5, 6], [1, 1, 1]]), columns=['A', 'B', 'C'])
+
+        expected_batches = [Batch(frames=df) for df in [expected_df1]]
+
+        self.assertEqual(expected_batches[0], reduced_batches[0])

--- a/test/integration_tests/test_select_executor.py
+++ b/test/integration_tests/test_select_executor.py
@@ -152,3 +152,13 @@ class SelectExecutorTest(unittest.TestCase):
             filters=[i for i in range(NUM_FRAMES)
                      if i < 2 or i == 5 or i > 7]))[0]
         self.assertEqual(actual_batch, expected_batch)
+
+    def test_select_and_limit(self):
+        select_query = "SELECT id,data FROM MyVideo LIMIT 5;"
+        actual_batch = perform_query(select_query)
+        actual_batch.sort()
+        expected_batch = list(create_dummy_batches(
+            num_frames=10, batch_size=5))
+
+        self.assertEqual(actual_batch.batch_size, expected_batch[0].batch_size)
+        self.assertEqual(actual_batch, expected_batch[0])

--- a/test/optimizer/generators/test_seq_scan_generator.py
+++ b/test/optimizer/generators/test_seq_scan_generator.py
@@ -17,14 +17,16 @@ import unittest
 
 from src.expression.tuple_value_expression import TupleValueExpression
 from src.optimizer.operators import (LogicalProject, LogicalGet, LogicalFilter,
-                                     LogicalOrderBy)
+                                     LogicalOrderBy, LogicalLimit)
 
 from src.optimizer.generators.seq_scan_generator import ScanGenerator
 from src.parser.types import ParserOrderBySortType
 from src.planner.seq_scan_plan import SeqScanPlan
 from src.planner.storage_plan import StoragePlan
 from src.planner.orderby_plan import OrderByPlan
+from src.planner.limit_plan import LimitPlan
 from src.planner.types import PlanNodeType
+from src.expression.constant_value_expression import ConstantValueExpression
 
 
 class SequentialScanGeneratorTest(unittest.TestCase):
@@ -58,3 +60,14 @@ class SequentialScanGeneratorTest(unittest.TestCase):
         self.assertEqual(ParserOrderBySortType.ASC, plan.orderby_list[0][1])
         self.assertEqual(TupleValueExpression('id'), plan.orderby_list[1][0])
         self.assertEqual(ParserOrderBySortType.DESC, plan.orderby_list[1][1])
+
+    def test_should_return_correct_plan_tree_for_limit_logical_tree(self):
+        # SELECT data, id FROM video limit 5;
+        logical_plan = LogicalLimit(ConstantValueExpression(5))
+
+        plan = ScanGenerator().build(logical_plan)
+
+        self.assertTrue(isinstance(plan, LimitPlan))
+        self.assertTrue(isinstance(
+            plan.limit_expression, ConstantValueExpression))
+        self.assertEqual(plan.limit_value, 5)

--- a/test/optimizer/test_plan_generator.py
+++ b/test/optimizer/test_plan_generator.py
@@ -18,7 +18,7 @@ from mock import patch
 
 from src.optimizer.operators import LogicalProject, LogicalGet, \
     LogicalFilter, LogicalInsert, Operator, LogicalCreateUDF, \
-    LogicalLoadData, LogicalUnion, LogicalOrderBy
+    LogicalLoadData, LogicalUnion, LogicalOrderBy, LogicalLimit
 from src.optimizer.plan_generator import PlanGenerator
 
 
@@ -62,6 +62,14 @@ class PlanGeneratorTest(unittest.TestCase):
         l_orderby = LogicalOrderBy(None)
         PlanGenerator().build(l_orderby)
         mock_instance.build.assert_called_with(l_orderby)
+
+    @patch("src.optimizer.plan_generator.ScanGenerator")
+    def test_should_return_use_scan_generator_for_logical_limit(self,
+                                                                mock_class):
+        mock_instance = mock_class.return_value
+        l_limit = LogicalLimit(None)
+        PlanGenerator().build(l_limit)
+        mock_instance.build.assert_called_with(l_limit)
 
     @patch("src.optimizer.plan_generator.ScanGenerator")
     def test_should_not_call_scan_generator_for_other_types(self,

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -209,6 +209,54 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(
             select_stmt.orderby_list[1][1], ParserOrderBySortType.DESC)
 
+    def test_select_statement_limit_class(self):
+        '''Testing limit clause in select statement
+        Class: SelectStatement'''
+
+        parser = Parser()
+
+        select_query = "SELECT CLASS, REDNESS FROM TAIPAI \
+                    WHERE (CLASS = 'VAN' AND REDNESS < 400 ) OR REDNESS > 700 \
+                    ORDER BY CLASS, REDNESS DESC LIMIT 3;"
+
+        eva_statement_list = parser.parse(select_query)
+        self.assertIsInstance(eva_statement_list, list)
+        self.assertEqual(len(eva_statement_list), 1)
+        self.assertEqual(eva_statement_list[0].stmt_type, StatementType.SELECT)
+
+        select_stmt = eva_statement_list[0]
+
+        # target List
+        self.assertIsNotNone(select_stmt.target_list)
+        self.assertEqual(len(select_stmt.target_list), 2)
+        self.assertEqual(
+            select_stmt.target_list[0].etype, ExpressionType.TUPLE_VALUE)
+        self.assertEqual(
+            select_stmt.target_list[1].etype, ExpressionType.TUPLE_VALUE)
+
+        # from_table
+        self.assertIsNotNone(select_stmt.from_table)
+        self.assertIsInstance(select_stmt.from_table, TableRef)
+        self.assertEqual(
+            select_stmt.from_table.table_info.table_name, 'TAIPAI')
+
+        # where_clause
+        self.assertIsNotNone(select_stmt.where_clause)
+
+        # orderby_clause
+        self.assertIsNotNone(select_stmt.orderby_list)
+        self.assertEqual(len(select_stmt.orderby_list), 2)
+        self.assertEqual(select_stmt.orderby_list[0][0].col_name, 'CLASS')
+        self.assertEqual(
+            select_stmt.orderby_list[0][1], ParserOrderBySortType.ASC)
+        self.assertEqual(select_stmt.orderby_list[1][0].col_name, 'REDNESS')
+        self.assertEqual(
+            select_stmt.orderby_list[1][1], ParserOrderBySortType.DESC)
+
+        # limit_count
+        self.assertIsNotNone(select_stmt.limit_count)
+        self.assertEqual(select_stmt.limit_count, 3)
+
     def test_table_ref(self):
         ''' Testing table info in TableRef
             Class: TableInfo

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -255,7 +255,9 @@ class ParserTests(unittest.TestCase):
 
         # limit_count
         self.assertIsNotNone(select_stmt.limit_count)
-        self.assertEqual(select_stmt.limit_count, 3)
+        self.assertEqual(select_stmt.limit_count, ConstantValueExpression(3))
+
+        print(select_stmt)
 
     def test_table_ref(self):
         ''' Testing table info in TableRef

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -257,8 +257,6 @@ class ParserTests(unittest.TestCase):
         self.assertIsNotNone(select_stmt.limit_count)
         self.assertEqual(select_stmt.limit_count, ConstantValueExpression(3))
 
-        print(select_stmt)
-
     def test_table_ref(self):
         ''' Testing table info in TableRef
             Class: TableInfo


### PR DESCRIPTION
Limit Implementation Steps:

1.  Add parser functionality

- Updated `parser_visitor.py` to process the limit clause (visitor just returns the number in the statement i.e 3 as a `ConstantValueExpression`)
- Updated `select_statement.py` to include limit count
- Test case in `test/parser/test_parser.py`

2. Create a logical plan

- Created a `LogicalLimit` operator in `optimizer/operators.py`
- Call the `LogicalLimit` operator in `optimzer/statement_to_opr_convertor.py` when creating the logical plan
- Test case in `test/optimizer/test_statement_to_opr_convertor.py`

3. Create a physical plan

- Updated `optimizer/plan_generator.py` to consider Limit as a Seq Scan node type
- Created a limit physical plan in `planner/limit_plan.py`. This just receives the information of the limit count from the logical plan and constructs a physical version of it
- Updated `optimizer/generators/seq_scan_generator.py` to construct the physical `LimitPlan` after receiving a `LogicalLimit` plan
- Test cases in `test/optimizer/generators/test_seq_scan_generator.py` and `test/optimizer/test_plan_generator.py`

4. Create an executor

- Created `executor/limit_executor.py` which actually processes how the engine will limit the number of rows returned
- Update the plan executor in `executor/plan_executor.py` to call the `LimitExecutor` upon processing a `LimitPlan` created in the previous step
- Test cases in `test/executor/test_limit_executor.py`

5. Add integration tests
- Added integration tests to test end to end system for limit in `test/integration_tests/test_select_executor.py`