### PR TITLE
Add cost attribute for UDF

### DIFF
--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -251,7 +251,7 @@ class CatalogManager(object):
 
     def create_udf(self, name: str, impl_file_path: str,
                    type: str, udf_io_list: List[UdfIO],
-                   udf_cost: int) -> UdfMetadata:
+                   udf_cost: int = -1) -> UdfMetadata:
         """Creates an udf metadata object and udf_io objects and persists them
         in database.
 

--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -250,7 +250,8 @@ class CatalogManager(object):
                      array_dimensions=dimensions, is_input=is_input)
 
     def create_udf(self, name: str, impl_file_path: str,
-                   type: str, udf_io_list: List[UdfIO]) -> UdfMetadata:
+                   type: str, udf_io_list: List[UdfIO],
+                   udf_cost: int) -> UdfMetadata:
         """Creates an udf metadata object and udf_io objects and persists them
         in database.
 
@@ -266,7 +267,8 @@ class CatalogManager(object):
             The persisted UdfMetadata object with the id field populated.
         """
 
-        metadata = self._udf_service.create_udf(name, impl_file_path, type)
+        metadata = self._udf_service.create_udf(
+            name, impl_file_path, type, udf_cost)
         for udf_io in udf_io_list:
             udf_io.udf_id = metadata.id
         self._udf_io_service.add_udf_io(udf_io_list)

--- a/src/catalog/models/udf.py
+++ b/src/catalog/models/udf.py
@@ -30,10 +30,17 @@ class UdfMetadata(BaseModel):
                          back_populates="_udf",
                          cascade='all, delete, delete-orphan')
 
-    def __init__(self, name: str, impl_file_path: str, type: str, cost: int):
+    def __init__(self,
+                 name: str,
+                 impl_file_path: str,
+                 type: str,
+                 cost: int = -1):
         self._name = name
         self._impl_file_path = impl_file_path
         self._type = type
+
+        # cost expects a positive integer, if not specified it is
+        # default to -1 (aka infinite).
         self._cost = cost
 
     @property

--- a/src/catalog/models/udf.py
+++ b/src/catalog/models/udf.py
@@ -29,7 +29,6 @@ class UdfMetadata(BaseModel):
     _cols = relationship('UdfIO',
                          back_populates="_udf",
                          cascade='all, delete, delete-orphan')
-    _metrics = relationship('UdfMetrics', back_populates='_udf')
 
     def __init__(self, name: str, impl_file_path: str, type: str, cost: int):
         self._name = name

--- a/src/catalog/models/udf.py
+++ b/src/catalog/models/udf.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, Integer
 from sqlalchemy.orm import relationship
 
 from src.catalog.models.base_model import BaseModel
@@ -24,15 +24,18 @@ class UdfMetadata(BaseModel):
     _name = Column('name', String(100), unique=True)
     _impl_file_path = Column('impl_file_path', String(128))
     _type = Column('type', String(100))
+    _cost = Column('cost', Integer)
 
     _cols = relationship('UdfIO',
                          back_populates="_udf",
                          cascade='all, delete, delete-orphan')
+    _metrics = relationship('UdfMetrics', back_populates='_udf')
 
-    def __init__(self, name: str, impl_file_path: str, type: str):
+    def __init__(self, name: str, impl_file_path: str, type: str, cost: int):
         self._name = name
         self._impl_file_path = impl_file_path
         self._type = type
+        self._cost = cost
 
     @property
     def id(self):
@@ -50,13 +53,18 @@ class UdfMetadata(BaseModel):
     def type(self):
         return self._type
 
+    @property
+    def cost(self):
+        return self._cost
+
     def __str__(self):
-        udf_str = 'udf: ({}, {}, {})\n'.format(
-            self.name, self.impl_file_path, self.type)
+        udf_str = 'udf: ({}, {}, {}, {})\n'.format(
+            self.name, self.impl_file_path, self.type, self.cost)
         return udf_str
 
     def __eq__(self, other):
         return self.id == other.id and \
             self.impl_file_path == other.impl_file_path and \
             self.name == other.name and \
-            self.type == other.type
+            self.type == other.type and \
+            self.cost == other.cost

--- a/src/catalog/services/udf_service.py
+++ b/src/catalog/services/udf_service.py
@@ -24,7 +24,7 @@ class UdfService(BaseService):
         super().__init__(UdfMetadata)
 
     def create_udf(self, name: str, impl_path: str, type: str,
-                   udf_cost: int) -> UdfMetadata:
+                   udf_cost: int = -1) -> UdfMetadata:
         """Creates a new udf entry
 
         Arguments:

--- a/src/catalog/services/udf_service.py
+++ b/src/catalog/services/udf_service.py
@@ -23,7 +23,8 @@ class UdfService(BaseService):
     def __init__(self):
         super().__init__(UdfMetadata)
 
-    def create_udf(self, name: str, impl_path: str, type: str) -> UdfMetadata:
+    def create_udf(self, name: str, impl_path: str, type: str,
+                   udf_cost: int) -> UdfMetadata:
         """Creates a new udf entry
 
         Arguments:
@@ -34,7 +35,7 @@ class UdfService(BaseService):
         Returns:
             UdfMetadata: Returns the new entry created
         """
-        metadata = self.model(name, impl_path, type)
+        metadata = self.model(name, impl_path, type, udf_cost)
         metadata = metadata.save()
         return metadata
 

--- a/src/executor/create_udf_executor.py
+++ b/src/executor/create_udf_executor.py
@@ -40,4 +40,4 @@ class CreateUDFExecutor(AbstractExecutor):
         impl_path = self.node.impl_path.absolute().as_posix()
         CatalogManager().create_udf(
             self.node.name, impl_path, self.node.udf_type,
-            io_list)
+            io_list, self.node.udf_cost)

--- a/src/optimizer/generators/create_udf_generator.py
+++ b/src/optimizer/generators/create_udf_generator.py
@@ -25,6 +25,7 @@ class CreateUDFGenerator(Generator):
         self._if_not_exists = None
         self._impl_path = None
         self._udf_type = None
+        self._udf_cost = None
 
     def _visit_logical_create_udf(self, operator: LogicalCreateUDF):
         self._name = operator.name
@@ -33,6 +34,7 @@ class CreateUDFGenerator(Generator):
         self._if_not_exists = operator.if_not_exists
         self._impl_path = operator.impl_path
         self._udf_type = operator.udf_type
+        self._udf_cost = operator.udf_cost
 
     def _visit(self, operator: Operator):
         if isinstance(operator, LogicalCreateUDF):
@@ -44,5 +46,6 @@ class CreateUDFGenerator(Generator):
         create_udf_plan = CreateUDFPlan(
             self._name,
             self._if_not_exists,
-            self._inputs, self._outputs, self._impl_path, self._udf_type)
+            self._inputs,
+            self._outputs, self._impl_path, self._udf_type, self._udf_cost)
         return create_udf_plan

--- a/src/optimizer/operators.py
+++ b/src/optimizer/operators.py
@@ -322,6 +322,7 @@ class LogicalCreateUDF(Operator):
                  outputs: List[UdfIO],
                  impl_path: Path,
                  udf_type: str = None,
+                 udf_cost: int = -1,
                  children=None):
         super().__init__(OperatorType.LOGICALCREATEUDF, children)
         self._name = name
@@ -330,6 +331,7 @@ class LogicalCreateUDF(Operator):
         self._outputs = outputs
         self._impl_path = impl_path
         self._udf_type = udf_type
+        self._udf_cost = udf_cost
 
     @property
     def name(self):
@@ -355,6 +357,10 @@ class LogicalCreateUDF(Operator):
     def udf_type(self):
         return self._udf_type
 
+    @property
+    def udf_cost(self):
+        return self._udf_cost
+
     def __eq__(self, other):
         is_subtree_equal = super().__eq__(other)
         if not isinstance(other, LogicalCreateUDF):
@@ -365,7 +371,8 @@ class LogicalCreateUDF(Operator):
                 and self.inputs == other.inputs
                 and self.outputs == other.outputs
                 and self.udf_type == other.udf_type
-                and self.impl_path == other.impl_path)
+                and self.impl_path == other.impl_path
+                and self.udf_cost == other.udf_cost)
 
 
 class LogicalLoadData(Operator):

--- a/src/optimizer/statement_to_opr_convertor.py
+++ b/src/optimizer/statement_to_opr_convertor.py
@@ -198,7 +198,8 @@ class StatementToPlanConvertor:
                                           statement.if_not_exists,
                                           annotated_inputs, annotated_outputs,
                                           statement.impl_path,
-                                          statement.udf_type)
+                                          statement.udf_type,
+                                          statement.udf_cost)
         self._plan = create_udf_opr
 
     def visit_load_data(self, statement: LoadDataStatement):

--- a/src/parser/create_udf_statement.py
+++ b/src/parser/create_udf_statement.py
@@ -40,6 +40,9 @@ class CreateUDFStatement(AbstractStatement):
             the path provided should be relative to the UDF dir.
         udf_type: str
             udf type. it ca be object detection, classification etc.
+        udf_cost: int
+            udf cost. an integer number that represents the compute
+            cost of a udf. If not set, it is default to -1 as infinite.
     """
 
     def __init__(self,
@@ -48,7 +51,8 @@ class CreateUDFStatement(AbstractStatement):
                  inputs: List[ColumnDefinition],
                  outputs: List[ColumnDefinition],
                  impl_path: str,
-                 udf_type: str = None):
+                 udf_type: str = None,
+                 udf_cost: int = -1):
         super().__init__(StatementType.CREATE_UDF)
         self._name = name
         self._if_not_exists = if_not_exists
@@ -56,11 +60,13 @@ class CreateUDFStatement(AbstractStatement):
         self._outputs = outputs
         self._impl_path = Path(impl_path)
         self._udf_type = udf_type
+        self._udf_cost = udf_cost
 
     def __str__(self) -> str:
-        print_str = 'CREATE UDF {} INPUT ({}) OUTPUT ({}) TYPE {} IMPL {}'. \
-                    format(self._name, self._inputs, self._outputs,
-                           self._udf_type, self._impl_path.name)
+        print_str = \
+            'CREATE UDF {} INPUT ({}) OUTPUT ({}) TYPE {} IMPL {} COST {}'. \
+            format(self._name, self._inputs, self._outputs,
+                   self._udf_type, self._impl_path.name, self._udf_cost)
         return print_str
 
     @property
@@ -87,6 +93,10 @@ class CreateUDFStatement(AbstractStatement):
     def udf_type(self):
         return self._udf_type
 
+    @property
+    def udf_cost(self):
+        return self._udf_cost
+
     def __eq__(self, other):
         if not isinstance(other, CreateUDFStatement):
             return False
@@ -95,4 +105,5 @@ class CreateUDFStatement(AbstractStatement):
                 and self.inputs == other.inputs
                 and self.outputs == other.outputs
                 and self.impl_path == other.impl_path
-                and self.udf_type == other.udf_type)
+                and self.udf_type == other.udf_type
+                and self.udf_cost == other.udf_cost)

--- a/src/parser/evaql/evaql_lexer.g4
+++ b/src/parser/evaql/evaql_lexer.g4
@@ -126,6 +126,7 @@ INPUT:                          'INPUT';
 OUTPUT:                         'OUTPUT';
 TYPE:                           'TYPE';
 IMPL:                           'IMPL';
+COST:                           'COST';
 
 
 // Common function names

--- a/src/parser/evaql/evaql_parser.g4
+++ b/src/parser/evaql/evaql_parser.g4
@@ -68,6 +68,7 @@ createUdf
       OUTPUT createDefinitions
       TYPE   udfType
       IMPL   udfImpl
+      COST   udfCost
     ;
 
 // details
@@ -81,6 +82,10 @@ udfType
 
 udfImpl
     : stringLiteral
+    ;
+
+udfCost
+    : decimalLiteral
     ;
 
 indexType

--- a/src/parser/evaql/evaql_parser.g4
+++ b/src/parser/evaql/evaql_parser.g4
@@ -68,6 +68,12 @@ createUdf
       OUTPUT createDefinitions
       TYPE   udfType
       IMPL   udfImpl
+    | CREATE UDF
+      ifNotExists?
+      udfName
+      INPUT  createDefinitions
+      OUTPUT createDefinitions
+      TYPE   udfType
       COST   udfCost
     ;
 
@@ -85,7 +91,7 @@ udfImpl
     ;
 
 udfCost
-    : decimalLiteral
+    : decimalLiteral | 
     ;
 
 indexType

--- a/src/parser/evaql/evaql_parser.g4
+++ b/src/parser/evaql/evaql_parser.g4
@@ -68,13 +68,7 @@ createUdf
       OUTPUT createDefinitions
       TYPE   udfType
       IMPL   udfImpl
-    | CREATE UDF
-      ifNotExists?
-      udfName
-      INPUT  createDefinitions
-      OUTPUT createDefinitions
-      TYPE   udfType
-      COST   udfCost
+      udfCost ?
     ;
 
 // details
@@ -91,7 +85,7 @@ udfImpl
     ;
 
 udfCost
-    : decimalLiteral | 
+    : COST decimalLiteral
     ;
 
 indexType

--- a/src/parser/parser_visitor.py
+++ b/src/parser/parser_visitor.py
@@ -589,6 +589,7 @@ class ParserVisitor(evaql_parserVisitor):
         output_definitions = []
         impl_path = None
         udf_type = None
+        udf_cost = -1
 
         for child in ctx.children:
             try:
@@ -618,6 +619,9 @@ class ParserVisitor(evaql_parserVisitor):
                 elif rule_idx == evaql_parser.RULE_udfImpl:
                     impl_path = self.visit(ctx.udfImpl()).value
 
+                elif rule_idx == evaql_parser.RULE_udfCost:
+                    udf_cost = self.visit(ctx.udfCost())
+
             except BaseException:
                 LoggingManager().log('CREATE UDF Failed', LoggingLevel.ERROR)
                 # stop parsing something bad happened
@@ -628,5 +632,6 @@ class ParserVisitor(evaql_parserVisitor):
             input_definitions,
             output_definitions,
             impl_path,
-            udf_type)
+            udf_type,
+            udf_cost)
         return stmt

--- a/src/planner/create_udf_plan.py
+++ b/src/planner/create_udf_plan.py
@@ -47,7 +47,8 @@ class CreateUDFPlan(AbstractPlan):
                  inputs: List[UdfIO],
                  outputs: List[UdfIO],
                  impl_file_path: Path,
-                 udf_type: str = None):
+                 udf_type: str = None,
+                 udf_cost: int = -1):
         super().__init__(PlanNodeType.CREATE_UDF)
         self._name = name
         self._if_not_exists = if_not_exists
@@ -55,6 +56,7 @@ class CreateUDFPlan(AbstractPlan):
         self._outputs = outputs
         self._impl_path = impl_file_path
         self._udf_type = udf_type
+        self._udf_cost = udf_cost
 
     @property
     def name(self):
@@ -79,3 +81,7 @@ class CreateUDFPlan(AbstractPlan):
     @property
     def udf_type(self):
         return self._udf_type
+    
+    @property
+    def udf_cost(self):
+        return self._udf_cost

--- a/test/catalog/services/test_udf_service.py
+++ b/test/catalog/services/test_udf_service.py
@@ -22,6 +22,7 @@ UDF_TYPE = 'classification'
 UDF_IMPL_PATH = 'file1'
 UDF_NAME = 'name'
 UDF_ID = 123
+UDF_DEFAULT_COST = -1
 
 
 class UdfServiceTest(TestCase):
@@ -30,7 +31,8 @@ class UdfServiceTest(TestCase):
     def test_create_udf_should_create_model(self, mocked):
         service = UdfService()
         service.create_udf(UDF_NAME, UDF_IMPL_PATH, UDF_TYPE)
-        mocked.assert_called_with(UDF_NAME, UDF_IMPL_PATH, UDF_TYPE)
+        mocked.assert_called_with(UDF_NAME, UDF_IMPL_PATH, UDF_TYPE,
+                                  UDF_DEFAULT_COST)
         mocked.return_value.save.assert_called_once()
 
     @patch("src.catalog.services.udf_service.UdfMetadata")

--- a/test/catalog/test_catalog_manager.py
+++ b/test/catalog/test_catalog_manager.py
@@ -195,7 +195,7 @@ class CatalogManagerTests(unittest.TestCase):
             'udf', 'sample.py', 'classification', udf_io_list)
         udfio_mock.return_value.add_udf_io.assert_called_with(udf_io_list)
         udf_mock.return_value.create_udf.assert_called_with(
-            'udf', 'sample.py', 'classification')
+            'udf', 'sample.py', 'classification', -1)
         self.assertEqual(actual, udf_mock.return_value.create_udf.return_value)
 
     @mock.patch('src.catalog.catalog_manager.init_db')

--- a/test/executor/test_create_udf_executor.py
+++ b/test/executor/test_create_udf_executor.py
@@ -32,9 +32,10 @@ class CreateUdfExecutorTest(unittest.TestCase):
                      'inputs': ['inp'],
                      'outputs': ['out'],
                      'impl_path': impl_path,
-                     'udf_type': 'classification'})
+                     'udf_type': 'classification',
+                     'udf_cost': 1})
 
         create_udf_executor = CreateUDFExecutor(plan)
         create_udf_executor.exec()
         catalog_instance.create_udf.assert_called_with(
-            'udf', 'test.py', 'classification', ['inp', 'out'])
+            'udf', 'test.py', 'classification', ['inp', 'out'], 1)

--- a/test/integration_tests/test_pytorch.py
+++ b/test/integration_tests/test_pytorch.py
@@ -64,3 +64,26 @@ class PytorchTest(unittest.TestCase):
         res = actual_batch.frames
         for idx in res.index:
             self.assertTrue('car' in res['label'][idx])
+
+    def test_should_run_pytorch_and_default_udf_cost(self):
+        create_udf_query = """CREATE UDF SSDObjectDetector
+                  INPUT  (Frame_Array NDARRAY (3, 256, 256))
+                  OUTPUT (label TEXT(10))
+                  TYPE  Classification
+                  IMPL  'src/udfs/ssd_object_detector.py';
+        """
+        perform_query(create_udf_query)
+        ssd_udf = CatalogManager().get_udf_by_name("SSDObjectDetector")
+        self.assertEqual(ssd_udf.cost, -1)
+
+    def test_should_run_pytorch_and_user_defined_udf_cost(self):
+        create_udf_query = """CREATE UDF SSDObjectDetector
+                  INPUT  (Frame_Array NDARRAY (3, 256, 256))
+                  OUTPUT (label TEXT(10))
+                  TYPE  Classification
+                  IMPL  'src/udfs/ssd_object_detector.py'
+                  COST  10;
+        """
+        perform_query(create_udf_query)
+        ssd_udf = CatalogManager().get_udf_by_name("SSDObjectDetector")
+        self.assertEqual(ssd_udf.cost, 10)

--- a/test/optimizer/test_statement_to_opr_convertor.py
+++ b/test/optimizer/test_statement_to_opr_convertor.py
@@ -146,6 +146,7 @@ statement_to_opr_convertor.column_definition_to_udf_io')
         stmt.impl_path = 'tmp.py'
         stmt.udf_type = 'classification'
         mock.side_effect = ['inp', 'out']
+        mock.udf_cost = 1
         convertor.visit_create_udf(stmt)
         mock.assert_any_call(stmt.inputs, True)
         mock.assert_any_call(stmt.outputs, False)
@@ -156,7 +157,8 @@ statement_to_opr_convertor.column_definition_to_udf_io')
             'inp',
             'out',
             stmt.impl_path,
-            stmt.udf_type)
+            stmt.udf_type,
+            stmt.udf_cost)
 
     def test_visit_should_call_create_udf(self):
         stmt = MagicMock(spec=CreateUDFStatement)

--- a/test/parser/test_parser_visitor.py
+++ b/test/parser/test_parser_visitor.py
@@ -254,7 +254,7 @@ class ParserVisitorTests(unittest.TestCase):
     @mock.patch('src.parser.parser_visitor.CreateUDFStatement')
     def test_visit_create_udf(self, create_udf_mock, visit_mock):
         ctx = MagicMock()
-        ctx.children = [MagicMock() for i in range(5)]
+        ctx.children = [MagicMock() for i in range(6)]
         ctx.children[0].getRuleIndex.return_value = evaql_parser.RULE_udfName
         ctx.children[1].getRuleIndex.return_value = evaql_parser. \
             RULE_ifNotExists
@@ -262,6 +262,7 @@ class ParserVisitorTests(unittest.TestCase):
             RULE_createDefinitions
         ctx.children[3].getRuleIndex.return_value = evaql_parser.RULE_udfType
         ctx.children[4].getRuleIndex.return_value = evaql_parser.RULE_udfImpl
+        ctx.children[5].getRuleIndex.return_value = evaql_parser.RULE_udfCost
 
         ctx.createDefinitions.return_value.__len__.return_value = 2
 
@@ -269,10 +270,12 @@ class ParserVisitorTests(unittest.TestCase):
         udf_type = 'classification'
         udf_impl = MagicMock()
         udf_impl.value = 'udf_impl'
+        udf_cost = 1
         values = {
             ctx.udfName.return_value: udf_name,
             ctx.udfType.return_value: udf_type,
             ctx.udfImpl.return_value: udf_impl,
+            ctx.udfCost.return_value: udf_cost,
             ctx.createDefinitions.return_value: 'col'}
 
         def side_effect(arg):
@@ -288,11 +291,12 @@ class ParserVisitorTests(unittest.TestCase):
              call(ctx.createDefinitions(0)),
              call(ctx.createDefinitions(1)),
              call(ctx.udfType()),
-             call(ctx.udfImpl())])
+             call(ctx.udfImpl()),
+             call(ctx.udfCost())])
 
         create_udf_mock.assert_called_once()
         create_udf_mock.assert_called_with(
-            udf_name, True, 'col', 'col', 'udf_impl', udf_type)
+            udf_name, True, 'col', 'col', 'udf_impl', udf_type, udf_cost)
 
         self.assertEqual(actual, create_udf_mock.return_value)
 


### PR DESCRIPTION
* Add cost attribute for UDF. If the attribute is not specified, it is default to `-1` to indicate infinite cost.
* Change catalog manager to support creating UDF with cost.
* Change UDF service to support creating UDF with cost.
* Change parser, statement, operator, planner and executor to support creating UDF with cost. Modify according test so that UDF creation with default value also passes the test.
* Change parser syntax to allow optional cost attribute.
* Add test case to test UDF can be created with specified cost attribute.