### PR TITLE
Add UDF accuracy metrics 

### DIFF
--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -26,6 +26,7 @@ from src.catalog.services.df_column_service import DatasetColumnService
 from src.catalog.services.df_service import DatasetService
 from src.catalog.services.udf_service import UdfService
 from src.catalog.services.udf_io_service import UdfIOService
+from src.catalog.services.udf_metrics_service import UdfMetricsService
 from src.utils.logging_manager import LoggingLevel
 from src.utils.logging_manager import LoggingManager
 
@@ -46,6 +47,7 @@ class CatalogManager(object):
         self._column_service = DatasetColumnService()
         self._udf_service = UdfService()
         self._udf_io_service = UdfIOService()
+        self._udf_metrics_service = UdfMetricsService()
 
     def reset(self):
         """
@@ -272,6 +274,19 @@ class CatalogManager(object):
             udf_io.udf_id = metadata.id
         self._udf_io_service.add_udf_io(udf_io_list)
         return metadata
+
+    def create_udf_metrics(self,
+                           udf_name: str,
+                           dataset: str,
+                           category: str,
+                           precision: float,
+                           recall: float):
+        udf = self.get_udf_by_name(udf_name)
+        return self._udf_metrics_service.create_udf_metrics(dataset,
+                                                            category,
+                                                            precision,
+                                                            recall,
+                                                            udf.id)
 
     def get_udf_by_name(self, name: str) -> UdfMetadata:
         """

--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -21,6 +21,7 @@ from src.catalog.models.df_column import DataFrameColumn
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.catalog.models.udf import UdfMetadata
 from src.catalog.models.udf_io import UdfIO
+from src.catalog.models.udf_metrics import UdfMetrics
 from src.catalog.services.df_column_service import DatasetColumnService
 from src.catalog.services.df_service import DatasetService
 from src.catalog.services.udf_service import UdfService

--- a/src/catalog/catalog_manager.py
+++ b/src/catalog/catalog_manager.py
@@ -21,7 +21,6 @@ from src.catalog.models.df_column import DataFrameColumn
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.catalog.models.udf import UdfMetadata
 from src.catalog.models.udf_io import UdfIO
-from src.catalog.models.udf_metrics import UdfMetrics
 from src.catalog.services.df_column_service import DatasetColumnService
 from src.catalog.services.df_service import DatasetService
 from src.catalog.services.udf_service import UdfService

--- a/src/catalog/models/udf.py
+++ b/src/catalog/models/udf.py
@@ -28,10 +28,10 @@ class UdfMetadata(BaseModel):
     _cols = relationship('UdfIO',
                          back_populates="_udf",
                          cascade='all, delete, delete-orphan')
-    
+
     _metrics = relationship('UdfMetrics',
-                         back_populates="_udf",
-                         cascade='all, delete, delete-orphan')
+                            back_populates="_udf",
+                            cascade='all, delete, delete-orphan')
 
     def __init__(self, name: str, impl_file_path: str, type: str):
         self._name = name

--- a/src/catalog/models/udf.py
+++ b/src/catalog/models/udf.py
@@ -28,6 +28,10 @@ class UdfMetadata(BaseModel):
     _cols = relationship('UdfIO',
                          back_populates="_udf",
                          cascade='all, delete, delete-orphan')
+    
+    _metrics = relationship('UdfMetrics',
+                         back_populates="_udf",
+                         cascade='all, delete, delete-orphan')
 
     def __init__(self, name: str, impl_file_path: str, type: str):
         self._name = name

--- a/src/catalog/models/udf_metrics.py
+++ b/src/catalog/models/udf_metrics.py
@@ -1,0 +1,82 @@
+from sqlalchemy import Column, String, Integer, Float, UniqueConstraint, \
+    ForeignKey
+from sqlalchemy.orm import relationship
+
+from src.catalog.models.base_model import BaseModel
+
+
+class UdfMetrics(BaseModel):
+    __tablename__ = 'udf_metrics'
+
+    _name = Column('name', String(100))
+    _dataset = Column('dataset', String(100))
+    _category = Column('category', String(100))
+    _precision = Column('precision', Float)
+    _recall = Column('recall', Float)
+    _udf_id = Column('udf_id', Integer,
+                     ForeignKey('udf.id'))
+    _udf = relationship('UdfMetadata', back_populates='_metrics')
+
+    __table_args__ = (
+        UniqueConstraint('name', 'dataset', 'category'), {}
+    )
+
+    def __init__(self,
+                 name, str,
+                 dataset: str,
+                 category: str,
+                 precision: float,
+                 recall: float,
+                 udf_id: int = None):
+        self._name = name
+        self._dataset = dataset
+        self._category = category
+        self._precision = precision
+        self._recall = recall
+        self._udf_io = udf_id
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def dataset(self):
+        return self._dataset
+
+    @property
+    def category(self):
+        return self._category
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def recall(self):
+        return self._recall
+
+    @property
+    def udf_id(self):
+        return self._udf_id
+
+    @udf_id.setter
+    def udf_id(self, value):
+        return self._udf_id
+
+    def __str__(self):
+        udf_metrics_str = 'UDF metrics: ({}, {}, {}, {}, {})\n'.format(
+            self.name, self.dataset, self.category, self.precision,
+            self.recall)
+        return udf_metrics_str
+
+    def __eq__(self, other):
+        return self.id == other.id and \
+            self.name == other.name and \
+            self.dataset == other.dataset and \
+            self.category == other.category and \
+            self.precision == other.precision and \
+            self.recall == other.recall

--- a/src/catalog/models/udf_metrics.py
+++ b/src/catalog/models/udf_metrics.py
@@ -18,22 +18,21 @@ class UdfMetrics(BaseModel):
     _udf = relationship('UdfMetadata', back_populates='_metrics')
 
     __table_args__ = (
-        UniqueConstraint('name', 'dataset', 'category'), {}
+        UniqueConstraint('name'), {}
     )
 
     def __init__(self,
-                 name, str,
                  dataset: str,
                  category: str,
                  precision: float,
                  recall: float,
                  udf_id: int = None):
-        self._name = name
+        self._name = dataset + ': ' + category
         self._dataset = dataset
         self._category = category
         self._precision = precision
         self._recall = recall
-        self._udf_io = udf_id
+        self._udf_id = udf_id
 
     @property
     def id(self):

--- a/src/catalog/services/udf_metrics_service.py
+++ b/src/catalog/services/udf_metrics_service.py
@@ -1,0 +1,18 @@
+from src.catalog.models.udf_metrics import UdfMetrics
+from src.catalog.services.base_service import BaseService
+
+
+class UdfMetricsService(BaseService):
+    def __init__(self):
+        super().__init__(UdfMetrics)
+
+    def create_udf_metrics(self,
+                           dataset: str,
+                           category: str,
+                           precision: float,
+                           recall: float,
+                           udf_id: int) -> UdfMetrics:
+        udf_metrics = self.model(
+            dataset, category, precision, recall, udf_id)
+        udf_metrics = udf_metrics.save()
+        return udf_metrics

--- a/src/executor/create_udf_metrics_executor.py
+++ b/src/executor/create_udf_metrics_executor.py
@@ -1,0 +1,20 @@
+from src.catalog.catalog_manager import CatalogManager
+from src.executor.abstract_executor import AbstractExecutor
+from src.planner.create_udf_metrics_plan import CreateUDFMetricsPlan
+
+
+class CreateUDFMetricsExecutor(AbstractExecutor):
+
+    def __init__(self, node: CreateUDFMetricsPlan):
+        super().__init__(node)
+
+    def validate(self):
+        pass
+
+    def exec(self):
+        CatalogManager().create_udf_metrics(
+            self.node.udf_name,
+            self.node.dataset,
+            self.node.category,
+            self.node.precision,
+            self.node.recall)

--- a/src/executor/plan_executor.py
+++ b/src/executor/plan_executor.py
@@ -28,6 +28,7 @@ from src.executor.load_executor import LoadDataExecutor
 from src.executor.storage_executor import StorageExecutor
 from src.executor.union_executor import UnionExecutor
 from src.executor.orderby_executor import OrderByExecutor
+from src.executor.create_udf_metrics_executor import CreateUDFMetricsExecutor
 
 
 class PlanExecutor:
@@ -79,6 +80,8 @@ class PlanExecutor:
             executor_node = OrderByExecutor(node=plan)
         elif plan_node_type == PlanNodeType.LIMIT:
             executor_node = LimitExecutor(node=plan)
+        elif plan_node_type == PlanNodeType.CREATE_UDF_METRICS:
+            executor_node = CreateUDFMetricsExecutor(node=plan)
 
         # Build Executor Tree for children
         for children in plan.children:
@@ -110,7 +113,8 @@ class PlanExecutor:
             PlanNodeType.CREATE,
             PlanNodeType.INSERT,
             PlanNodeType.CREATE_UDF,
-            PlanNodeType.LOAD_DATA)
+            PlanNodeType.LOAD_DATA,
+            PlanNodeType.CREATE_UDF_METRICS)
         if execution_tree.node.node_type in _INSERT_CREATE_LOAD:
             execution_tree.exec()
         else:

--- a/src/optimizer/generators/create_udf_metrics_generator.py
+++ b/src/optimizer/generators/create_udf_metrics_generator.py
@@ -1,0 +1,35 @@
+from src.optimizer.generators.base import Generator
+from src.optimizer.operators import LogicalCreateUDFMetrics, Operator
+from src.planner.create_udf_metrics_plan import CreateUDFMetricsPlan
+
+
+class CreateUDFMetricsGenerator(Generator):
+    def __init__(self):
+        self._udf_name = None
+        self._dataset = None
+        self._category = None
+        self._precision = None
+        self._recall = None
+
+    def _visit_logical_create_udf_metrics(self,
+                                          operator: LogicalCreateUDFMetrics):
+        self._udf_name = operator.udf_name
+        self._dataset = operator.dataset
+        self._category = operator.category
+        self._precision = operator.precision
+        self._recall = operator.recall
+
+    def _visit(self, operator: Operator):
+        if isinstance(operator, LogicalCreateUDFMetrics):
+            self._visit_logical_create_udf_metrics(operator)
+
+    def build(self, operator: Operator):
+        self.__init__()
+        self._visit(operator)
+        create_udf_metrics_plan = CreateUDFMetricsPlan(
+            self._name,
+            self._dataset,
+            self._category,
+            self._precision,
+            self._recall)
+        return create_udf_metrics_plan

--- a/src/optimizer/generators/create_udf_metrics_generator.py
+++ b/src/optimizer/generators/create_udf_metrics_generator.py
@@ -27,7 +27,7 @@ class CreateUDFMetricsGenerator(Generator):
         self.__init__()
         self._visit(operator)
         create_udf_metrics_plan = CreateUDFMetricsPlan(
-            self._name,
+            self._udf_name,
             self._dataset,
             self._category,
             self._precision,

--- a/src/optimizer/operators.py
+++ b/src/optimizer/operators.py
@@ -370,9 +370,14 @@ class LogicalCreateUDF(Operator):
 
 
 class LogicalCreateUDFMetrics(Operator):
-    def __init__(self, udf_name: str,
-                 dataset: str, category: str,
-                 precision: float, recall: float):
+    def __init__(self,
+                 udf_name: str,
+                 dataset: str,
+                 category: str,
+                 precision: float,
+                 recall: float,
+                 children=None):
+        super().__init__(OperatorType.LOGICALCREATEUDFMETRICS, children)
         self._udf_name = udf_name
         self._dataset = dataset
         self._category = category

--- a/src/optimizer/operators.py
+++ b/src/optimizer/operators.py
@@ -40,6 +40,7 @@ class OperatorType(IntEnum):
     LOGICALUNION = auto()
     LOGICALORDERBY = auto()
     LOGICALLIMIT = auto()
+    LOGICALCREATEUDFMETRICS = auto()
 
 
 class Operator:
@@ -366,6 +367,48 @@ class LogicalCreateUDF(Operator):
                 and self.outputs == other.outputs
                 and self.udf_type == other.udf_type
                 and self.impl_path == other.impl_path)
+
+
+class LogicalCreateUDFMetrics(Operator):
+    def __init__(self, udf_name: str,
+                 dataset: str, category: str,
+                 precision: float, recall: float):
+        self._udf_name = udf_name
+        self._dataset = dataset
+        self._category = category
+        self._precision = precision
+        self._recall = recall
+
+    @property
+    def udf_name(self):
+        return self._udf_name
+
+    @property
+    def dataset(self):
+        return self._dataset
+
+    @property
+    def category(self):
+        return self._category
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def recall(self):
+        return self._recall
+
+    def __eq__(self, other):
+        is_subtree_equal = super().__eq__(other)
+        if not isinstance(other, LogicalCreateUDFMetrics):
+            return False
+        return (is_subtree_equal and
+                self.udf_name == other.udf_name and
+                self.dataset == other.dataset and
+                self.category == other.category and
+                self.precision == other.precision and
+                self.recall == other.recall)
 
 
 class LogicalLoadData(Operator):

--- a/src/optimizer/plan_generator.py
+++ b/src/optimizer/plan_generator.py
@@ -17,6 +17,8 @@ from src.optimizer.generators.insert_generator import InsertGenerator
 from src.optimizer.generators.create_generator import CreateGenerator
 from src.optimizer.generators.create_udf_generator import CreateUDFGenerator
 from src.optimizer.generators.load_generator import LoadDataGenerator
+from src.optimizer.generators.create_udf_metrics_generator import \
+    CreateUDFMetricsGenerator
 from src.optimizer.operators import Operator, OperatorType
 
 
@@ -33,6 +35,7 @@ class PlanGenerator:
     _CREATE_NODE_TYPE = OperatorType.LOGICALCREATE
     _CREATE_UDF_NODE_TYPE = OperatorType.LOGICALCREATEUDF
     _LOAD_NODE_TYPE = OperatorType.LOGICALLOADDATA
+    _CREATE_UDF_METRICS_NODE_TYPE = OperatorType.LOGICALCREATEUDFMETRICS
 
     def build(self, logical_plan: Operator):
         if logical_plan.type in self._SCAN_NODE_TYPES:
@@ -45,3 +48,5 @@ class PlanGenerator:
             return CreateUDFGenerator().build(logical_plan)
         if logical_plan.type is self._LOAD_NODE_TYPE:
             return LoadDataGenerator().build(logical_plan)
+        if logical_plan.type is self._CREATE_UDF_METRICS_NODE_TYPE:
+            return CreateUDFMetricsGenerator().build(logical_plan)

--- a/src/optimizer/statement_to_opr_convertor.py
+++ b/src/optimizer/statement_to_opr_convertor.py
@@ -18,13 +18,15 @@ from src.optimizer.operators import (LogicalGet, LogicalFilter, LogicalProject,
                                      LogicalInsert, LogicalCreate,
                                      LogicalCreateUDF, LogicalLoadData,
                                      LogicalQueryDerivedGet, LogicalUnion,
-                                     LogicalOrderBy, LogicalLimit)
+                                     LogicalOrderBy, LogicalLimit,
+                                     LogicalCreateUDFMetrics)
 from src.parser.statement import AbstractStatement
 from src.parser.select_statement import SelectStatement
 from src.parser.insert_statement import InsertTableStatement
 from src.parser.create_statement import CreateTableStatement
 from src.parser.create_udf_statement import CreateUDFStatement
 from src.parser.load_statement import LoadDataStatement
+from src.parser.create_udf_metrics_statement import CreateUDFMetricsStatement
 from src.optimizer.optimizer_utils import (bind_table_ref, bind_columns_expr,
                                            bind_predicate_expr,
                                            create_column_metadata,
@@ -201,6 +203,14 @@ class StatementToPlanConvertor:
                                           statement.udf_type)
         self._plan = create_udf_opr
 
+    def visit_create_udf_metrics(self, statement: CreateUDFMetricsStatement):
+        create_udf_metrics_opr = LogicalCreateUDFMetrics(statement.udf_name,
+                                                         statement.dataset,
+                                                         statement.category,
+                                                         statement.precision,
+                                                         statement.recall)
+        self._plan = create_udf_metrics_opr
+
     def visit_load_data(self, statement: LoadDataStatement):
         """Convertor for parsed load data statement
         If the input table already exists we return its
@@ -236,6 +246,8 @@ class StatementToPlanConvertor:
             self.visit_create_udf(statement)
         elif isinstance(statement, LoadDataStatement):
             self.visit_load_data(statement)
+        elif isinstance(statement, CreateUDFMetricsStatement):
+            self.visit_create_udf_metrics(statement)
         return self._plan
 
     @property

--- a/src/parser/create_udf_metrics_statement.py
+++ b/src/parser/create_udf_metrics_statement.py
@@ -1,0 +1,53 @@
+from src.parser.statement import AbstractStatement
+from src.parser.types import StatementType
+
+
+class CreateUDFMetricsStatement(AbstractStatement):
+    def __init__(self,
+                 udf_name: str,
+                 dataset: str,
+                 category: str,
+                 precision: float,
+                 recall: float):
+        super().__init__(StatementType.CREATE_UDF_METRICS)
+        self._udf_name = udf_name
+        self._dataset = dataset
+        self._category = category
+        self._precision = precision
+        self._recall = recall
+
+    def __str__(self) -> str:
+        print_str = 'CREATE UDF METRICS {} DATASET {} CATEGORY {} ' \
+            'PRECISION {:.4f} RECALL {:.4f}'.format(
+                self._udf_name, self._dataset, self._category,
+                self._precision, self._recall)
+        return print_str
+
+    @property
+    def udf_name(self):
+        return self._udf_name
+
+    @property
+    def dataset(self):
+        return self._dataset
+
+    @property
+    def category(self):
+        return self._category
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def recall(self):
+        return self._recall
+
+    def __eq__(self, other):
+        if not isinstance(other, CreateUDFMetricsStatement):
+            return False
+        return (self.udf_name == other.udf_name and
+                self.dataset == other.dataset and
+                self.category == other.category and
+                self.precision == other.precision and
+                self.recall == other.recall)

--- a/src/parser/evaql/evaql_lexer.g4
+++ b/src/parser/evaql/evaql_lexer.g4
@@ -9,8 +9,8 @@ SPACE:                               [ \t\r\n]+    -> channel(HIDDEN);
 SPEC_EVAQL_COMMENT:                  '/*!' .+? '*/' -> channel(EVAQLCOMMENT);
 COMMENT_INPUT:                       '/*' .*? '*/' -> channel(HIDDEN);
 LINE_COMMENT:                        (
-                                       ('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF) 
-                                       | '--' ('\r'? '\n' | EOF) 
+                                       ('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF)
+                                       | '--' ('\r'? '\n' | EOF)
                                      ) -> channel(HIDDEN);
 
 // Keywords
@@ -122,11 +122,15 @@ VALUE:                               'VALUE';
 
 // UDF
 UDF:						                'UDF';
+UDFMETRICS:                     'UDFMETRICS';
 INPUT:                          'INPUT';
 OUTPUT:                         'OUTPUT';
 TYPE:                           'TYPE';
 IMPL:                           'IMPL';
-
+DATASET:                        'DATASET';
+CATEGORY:                       'CATEGORY';
+PRECISION:                      'PRECISION';
+RECALL:                         'RECALL';
 
 // Common function names
 
@@ -215,23 +219,23 @@ ID:                                  ID_LITERAL;
 // DOUBLE_QUOTE_ID:                  '"' ~'"'+ '"';
 REVERSE_QUOTE_ID:                    '`' ~'`'+ '`';
 STRING_USER_NAME:                    (
-                                       SQUOTA_STRING | DQUOTA_STRING 
+                                       SQUOTA_STRING | DQUOTA_STRING
                                        | BQUOTA_STRING | ID_LITERAL
-                                     ) '@' 
+                                     ) '@'
                                      (
-                                       SQUOTA_STRING | DQUOTA_STRING 
+                                       SQUOTA_STRING | DQUOTA_STRING
                                        | BQUOTA_STRING | ID_LITERAL
                                      );
 LOCAL_ID:                            '@'
                                 (
-                                  [A-Z0-9._$]+ 
+                                  [A-Z0-9._$]+
                                   | SQUOTA_STRING
                                   | DQUOTA_STRING
                                   | BQUOTA_STRING
                                 );
-GLOBAL_ID:                           '@' '@' 
+GLOBAL_ID:                           '@' '@'
                                 (
-                                  [A-Z0-9._$]+ 
+                                  [A-Z0-9._$]+
                                   | BQUOTA_STRING
                                 );
 

--- a/src/parser/evaql/evaql_parser.g4
+++ b/src/parser/evaql/evaql_parser.g4
@@ -25,7 +25,7 @@ emptyStatement
     ;
 
 ddlStatement
-    : createDatabase | createTable | createIndex | createUdf
+    : createDatabase | createTable | createIndex | createUdf | createUdfMetrics
     | dropDatabase | dropTable | dropIndex
     ;
 
@@ -70,6 +70,16 @@ createUdf
       IMPL   udfImpl
     ;
 
+// Create UDF Accuracy Metrics
+createUdfMetrics
+    : CREATE UDFMETRICS
+      udfName
+      DATASET    udfDataset
+      CATEGORY   udfCategory
+      PRECISION  udfPrecision
+      RECALL     udfRecall
+    ;
+
 // details
 udfName
     : uid
@@ -81,6 +91,22 @@ udfType
 
 udfImpl
     : stringLiteral
+    ;
+
+udfDataset
+    : stringLiteral
+    ;
+
+udfCategory
+    : stringLiteral
+    ;
+
+udfPrecision
+    : realLiteral
+    ;
+
+udfRecall
+    : realLiteral
     ;
 
 indexType
@@ -347,6 +373,10 @@ dottedId
 
 decimalLiteral
     : DECIMAL_LITERAL | ZERO_DECIMAL | ONE_DECIMAL | TWO_DECIMAL
+    ;
+
+realLiteral
+    : REAL_LITERAL
     ;
 
 stringLiteral

--- a/src/parser/parser_visitor.py
+++ b/src/parser/parser_visitor.py
@@ -653,10 +653,10 @@ class ParserVisitor(evaql_parserVisitor):
                     udf_name = self.visit(ctx.udfName())
 
                 elif rule_idx == evaql_parser.RULE_udfDataset:
-                    dataset = self.visit(ctx.udfDataset())
+                    dataset = self.visit(ctx.udfDataset()).value
 
                 elif rule_idx == evaql_parser.RULE_udfCategory:
-                    category = self.visit(ctx.udfCategory())
+                    category = self.visit(ctx.udfCategory()).value
 
                 elif rule_idx == evaql_parser.RULE_udfPrecision:
                     precision = self.visit(ctx.udfPrecision())
@@ -664,8 +664,8 @@ class ParserVisitor(evaql_parserVisitor):
                 elif rule_idx == evaql_parser.RULE_udfRecall:
                     recall = self.visit(ctx.udfRecall())
 
-            except BaseException:
-                LoggingManager().log('CREATE UDFMETRICS Failed',
+            except BaseException as e:
+                LoggingManager().log('CREATE UDFMETRICS Failed: {}'.format(e),
                                      LoggingLevel.ERROR)
                 # stop parsing something bad happened
                 return None

--- a/src/parser/types.py
+++ b/src/parser/types.py
@@ -32,6 +32,7 @@ class StatementType(IntEnum):
     INSERT = 3,
     CREATE_UDF = 4,
     LOAD_DATA = 5,
+    CREATE_UDF_METRICS = 6,
     # add other types
 
 

--- a/src/planner/create_udf_metrics_plan.py
+++ b/src/planner/create_udf_metrics_plan.py
@@ -1,0 +1,37 @@
+from src.planner.abstract_plan import AbstractPlan
+from src.planner.types import PlanNodeType
+
+
+class CreateUDFMetricsPlan(AbstractPlan):
+    def __init__(self,
+                 udf_name: str,
+                 dataset: str,
+                 category: str,
+                 precision: float,
+                 recall: float):
+        super().__init__(PlanNodeType.CREATE_UDF_METRICS)
+        self._udf_name = udf_name
+        self._dataset = dataset
+        self._category = category
+        self._precision = precision
+        self._recall = recall
+
+    @property
+    def udf_name(self):
+        return self._udf_name
+
+    @property
+    def dataset(self):
+        return self._dataset
+
+    @property
+    def category(self):
+        return self._category
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def recall(self):
+        return self._recall

--- a/src/planner/types.py
+++ b/src/planner/types.py
@@ -27,4 +27,5 @@ class PlanNodeType(IntEnum):
     UNION = 8
     ORDER_BY = 9
     LIMIT = 10
+    CREATE_UDF_METRICS = 11
     # add other types

--- a/test/catalog/services/test_udf_metrics_service.py
+++ b/test/catalog/services/test_udf_metrics_service.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from mock import patch, MagicMock
+
+from src.catalog.models.udf import UdfMetadata
+from src.catalog.models.udf_io import UdfIO
+from src.catalog.services.udf_metrics_service import UdfMetricsService
+
+
+class UdfMetricsServiceTest(TestCase):
+
+    @patch("src.catalog.services.udf_metrics_service.UdfMetrics")
+    def test_create_udf_metrics_should_create_model(self, mocked):
+        service = UdfMetricsService()
+        service.create_udf_metrics(
+            'dataset',
+            'category',
+            0.1,
+            0.2,
+            123456)
+        mocked.assert_called_with(
+            'dataset',
+            'category',
+            0.1,
+            0.2,
+            123456)
+        mocked.return_value.save.assert_called_once()

--- a/test/catalog/services/test_udf_metrics_service.py
+++ b/test/catalog/services/test_udf_metrics_service.py
@@ -1,9 +1,7 @@
 from unittest import TestCase
 
-from mock import patch, MagicMock
+from mock import patch
 
-from src.catalog.models.udf import UdfMetadata
-from src.catalog.models.udf_io import UdfIO
 from src.catalog.services.udf_metrics_service import UdfMetricsService
 
 

--- a/test/executor/test_create_udf_metrics_executor.py
+++ b/test/executor/test_create_udf_metrics_executor.py
@@ -1,0 +1,21 @@
+import unittest
+from mock import patch, MagicMock
+from src.executor.create_udf_metrics_executor import CreateUDFMetricsExecutor
+
+
+class CreateUdfMetricsExecutorTest(unittest.TestCase):
+    @patch('src.executor.create_udf_metrics_executor.CatalogManager')
+    def test_should_create_udf_metrics(self, mock):
+        catalog_instance = mock.return_value
+        plan = type("CreateUDFMetricsPlan",
+                    (),
+                    {'udf_name': 'name',
+                     'dataset': 'dataset',
+                     'category': 'category',
+                     'precision': 0.1,
+                     'recall': 0.2})
+
+        create_udf_metrics_executor = CreateUDFMetricsExecutor(plan)
+        create_udf_metrics_executor.exec()
+        catalog_instance.create_udf_metrics.assert_called_with(
+            'name', 'dataset', 'category', 0.1, 0.2)

--- a/test/executor/test_create_udf_metrics_executor.py
+++ b/test/executor/test_create_udf_metrics_executor.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import patch, MagicMock
+from mock import patch
 from src.executor.create_udf_metrics_executor import CreateUDFMetricsExecutor
 
 

--- a/test/integration_tests/test_create_udf_metrics_executor.py
+++ b/test/integration_tests/test_create_udf_metrics_executor.py
@@ -1,13 +1,7 @@
-import os
 import unittest
 
-import numpy as np
-import pandas as pd
-
 from src.catalog.catalog_manager import CatalogManager
-from src.models.storage.batch import Batch
-from src.readers.opencv_reader import OpenCVReader
-from test.util import create_sample_video, create_dummy_batches, perform_query
+from test.util import perform_query
 
 
 class CreateUDFMetricsExecutorTest(unittest.TestCase):

--- a/test/integration_tests/test_create_udf_metrics_executor.py
+++ b/test/integration_tests/test_create_udf_metrics_executor.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.catalog.catalog_manager import CatalogManager
+from src.models.storage.batch import Batch
+from src.readers.opencv_reader import OpenCVReader
+from test.util import create_sample_video, create_dummy_batches, perform_query
+
+
+class CreateUDFMetricsExecutorTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        CatalogManager().reset()
+        load_query = """CREATE UDF FastRCNNObjectDetector
+                  INPUT  (Frame_Array NDARRAY (3, 256, 256))
+                  OUTPUT (label TEXT(10))
+                  TYPE  Classification
+                  IMPL  'src/udfs/fastrcnn_object_detector.py';
+        """
+        perform_query(load_query)
+
+    def test_create_udf_metrics(self):
+        query = """CREATE UDFMETRICS FastRCNNObjectDetector
+                   DATASET 'COCO' CATEGORY 'Car'
+                   PRECISION 0.6 RECALL 0.5;"""
+        perform_query(query)

--- a/test/optimizer/test_plan_generator.py
+++ b/test/optimizer/test_plan_generator.py
@@ -18,7 +18,8 @@ from mock import patch
 
 from src.optimizer.operators import LogicalProject, LogicalGet, \
     LogicalFilter, LogicalInsert, Operator, LogicalCreateUDF, \
-    LogicalLoadData, LogicalUnion, LogicalOrderBy, LogicalLimit
+    LogicalLoadData, LogicalUnion, LogicalOrderBy, LogicalLimit, \
+    LogicalCreateUDFMetrics
 from src.optimizer.plan_generator import PlanGenerator
 
 
@@ -102,6 +103,18 @@ class PlanGeneratorTest(unittest.TestCase):
         l_create_udf = LogicalCreateUDF('udf', True, [], [], 'tmp')
         PlanGenerator().build(l_create_udf)
         mock_instance.build.assert_called_with(l_create_udf)
+
+    @patch('src.optimizer.plan_generator.CreateUDFMetricsGenerator')
+    def test_should_call_create_udf_generator_for_logical_create_udf_metrics(
+            self, mock):
+        mock_instance = mock.return_value
+        l_create_udf_metrics = LogicalCreateUDFMetrics('name',
+                                                       'dataset',
+                                                       'category',
+                                                       0.1,
+                                                       0.2)
+        PlanGenerator().build(l_create_udf_metrics)
+        mock_instance.build.assert_called_with(l_create_udf_metrics)
 
     @patch('src.optimizer.plan_generator.LoadDataGenerator')
     def test_should_Call_load_data_generator(self, mock):

--- a/test/optimizer/test_statement_to_opr_convertor.py
+++ b/test/optimizer/test_statement_to_opr_convertor.py
@@ -23,6 +23,7 @@ from src.parser.create_udf_statement import CreateUDFStatement
 from src.parser.insert_statement import InsertTableStatement
 from src.parser.create_statement import CreateTableStatement
 from src.parser.load_statement import LoadDataStatement
+from src.parser.create_udf_metrics_statement import CreateUDFMetricsStatement
 from src.parser.parser import Parser
 
 from src.optimizer.operators import (LogicalProject, LogicalGet, LogicalFilter,
@@ -158,11 +159,39 @@ statement_to_opr_convertor.column_definition_to_udf_io')
             stmt.impl_path,
             stmt.udf_type)
 
+    @patch('src.optimizer.statement_to_opr_convertor.LogicalCreateUDFMetrics')
+    def test_visit_create_udf_metrics(self, l_create_udf_metrics_mock):
+        convertor = StatementToPlanConvertor()
+        stmt = MagicMock()
+        stmt.udf_name = 'name'
+        stmt.dataset = 'dataset'
+        stmt.category = 'category'
+        stmt.precision = 0.1
+        stmt.recall = 0.2
+        convertor.visit_create_udf_metrics(stmt)
+        l_create_udf_metrics_mock.assert_called_once()
+        l_create_udf_metrics_mock.assert_called_with(
+            stmt.udf_name,
+            stmt.dataset,
+            stmt.category,
+            stmt.precision,
+            stmt.recall)
+
     def test_visit_should_call_create_udf(self):
         stmt = MagicMock(spec=CreateUDFStatement)
         convertor = StatementToPlanConvertor()
         mock = MagicMock()
         convertor.visit_create_udf = mock
+
+        convertor.visit(stmt)
+        mock.assert_called_once()
+        mock.assert_called_with(stmt)
+
+    def test_visit_should_call_create_udf_metrics(self):
+        stmt = MagicMock(spec=CreateUDFMetricsStatement)
+        convertor = StatementToPlanConvertor()
+        mock = MagicMock()
+        convertor.visit_create_udf_metrics = mock
 
         convertor.visit(stmt)
         mock.assert_called_once()

--- a/test/parser/test_parser_visitor.py
+++ b/test/parser/test_parser_visitor.py
@@ -314,8 +314,10 @@ class ParserVisitorTests(unittest.TestCase):
             RULE_udfRecall
 
         udf_name = 'name'
-        dataset = 'dataset'
-        category = 'category'
+        dataset = MagicMock()
+        dataset.value = 'dataset'
+        category = MagicMock()
+        category.value = 'category'
         precision = 0.1
         recall = 0.2
         values = {
@@ -342,7 +344,7 @@ class ParserVisitorTests(unittest.TestCase):
 
         create_udf_metrics_mock.assert_called_once()
         create_udf_metrics_mock.assert_called_with(
-            udf_name, dataset, category, precision, recall)
+            udf_name, dataset.value, category.value, precision, recall)
 
         self.assertEqual(actual, create_udf_metrics_mock.return_value)
 

--- a/test/planner/test_plan.py
+++ b/test/planner/test_plan.py
@@ -23,6 +23,7 @@ from src.planner.insert_plan import InsertPlan
 from src.planner.create_udf_plan import CreateUDFPlan
 from src.planner.load_data_plan import LoadDataPlan
 from src.planner.union_plan import UnionPlan
+from src.planner.create_udf_metrics_plan import CreateUDFMetricsPlan
 from src.planner.types import PlanNodeType
 
 
@@ -75,6 +76,25 @@ class PlanNodeTests(unittest.TestCase):
         self.assertEqual(node.outputs, [udfIO])
         self.assertEqual(node.impl_path, impl_path)
         self.assertEqual(node.udf_type, ty)
+
+    def test_create_udf_metrics_plan(self):
+        udf_name = 'name'
+        dataset = 'dataset'
+        category = 'category'
+        precision = 0.1
+        recall = 0.2
+        node = CreateUDFMetricsPlan(
+            udf_name,
+            dataset,
+            category,
+            precision,
+            recall)
+        self.assertEqual(node.node_type, PlanNodeType.CREATE_UDF_METRICS)
+        self.assertEqual(node.udf_name, udf_name)
+        self.assertEqual(node.dataset, dataset)
+        self.assertEqual(node.category, category)
+        self.assertEqual(node.precision, precision)
+        self.assertEqual(node.recall, recall)
 
     def test_load_data_plan(self):
         table_metainfo = 'meta_info'


### PR DESCRIPTION
1. Parser change.
    * Parser syntax change to support statement `CREATE UDFMETRICS <udf> DATASET <dataset> CATEGORY <category> PRECISION <precision> RECALL <recall>`. Dataset and category are string literals. Precision and recall are real literals.
    * Add a visitor to parser `CreateUDFMetricsStatement`.
    * Add `CreateUDFMetricsStatement`.
    * Add according test cases.
2. Optimizer change.
    * Support conversion from statement to operator.
    * Add `LogicalCreateUDFMetrics` operator for optimizer.
    * Support plan generation for `CreateUDFMetrics`.
    * Add `CreateUDFMetricsGenerator`.
    * Add according test cases.
3. Planner change.
    * Add `CreateUDFMetricsPlan`.
    * Add according test cases.
4. Executor changes.
    * Support `CreateUDFMetrics` execution.
    * Add `CreateUDFMetricsExecutor`.
    * Add according test cases.
5. Catalog changes.
    * Add `CreateUDFMetrics` in catalog manager.
    * Link UDF metrics in UDF.
    * Add UDF metrics model. Each attribute is mapped to parser token except name. Name is concatenation of both dataset and category and it is expected to be unique.
    * Add UDF metrics service.
    * Add according test cases.