### PR TITLE
Freeze pyspark to 3.0.2

### DIFF
--- a/script/install/conda_eva_environment.yml
+++ b/script/install/conda_eva_environment.yml
@@ -27,10 +27,11 @@ dependencies:
   - mock
   - pytest-asyncio
   - flake8
-  - sphinx 
+  - sphinx
   - sphinx_rtd_theme
   - pip:
     - antlr4-python3-runtime==4.8
+    - pyspark==3.0.2
     - petastorm
     - pre-commit
     - flake8

--- a/script/install/conda_eva_environment.yml
+++ b/script/install/conda_eva_environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - pip:
     - antlr4-python3-runtime==4.8
     - pyspark==3.0.2
-    - petastorm
+    - petastorm==0.9.8
     - pre-commit
     - flake8
     - pytest


### PR DESCRIPTION
Tests fail with pumped up pyspark version (3.1.1).

Failed build: https://app.circleci.com/pipelines/github/georgia-tech-db/eva/63/workflows/6772c302-75e8-49d7-a799-054030414d93/jobs/64

Successful build: https://app.circleci.com/pipelines/github/georgia-tech-db/eva/61/workflows/760c47f8-f793-4308-b063-5decb17e6435/jobs/61
