### PR TITLE
Load and Read speed improvement

### DIFF
--- a/eva.yml
+++ b/eva.yml
@@ -7,7 +7,7 @@ core:
 executor:
   # batch_mem_size configures the number of rows processed by the execution engine in one iteration
   # #rows = max(1, row_mem_size / batch_mem_size)
-  batch_mem_size: 300000000 # 300mb
+  batch_mem_size: 30000000 # 30mb
 
   # batch size used for gpu_operations
   gpu_batch_size: 1
@@ -19,7 +19,7 @@ storage:
   # https://petastorm.readthedocs.io/en/latest/api.html#module-petastorm.reader
   petastorm: {'cache_type' : 'local-disk',
               'cache_location' : '.cache',
-              'cache_size_limit' : 10000000000, #10gb
+              'cache_size_limit' : 4000000000, #4gb
               'cache_row_size_estimate' : 512}
 
 pyspark:

--- a/eva.yml
+++ b/eva.yml
@@ -10,7 +10,7 @@ executor:
   batch_mem_size: 300000000 # 300mb
 
   # batch size used for gpu_operations
-  gpu_batch_size: 20
+  gpu_batch_size: 1
 
   gpus: {'130.207.125.60': [0]}
 storage:

--- a/eva.yml
+++ b/eva.yml
@@ -16,12 +16,18 @@ executor:
 storage:
   engine: "src.storage.petastorm_storage_engine.PetastormStorageEngine"
   path_prefix: "/tmp"
+  # https://petastorm.readthedocs.io/en/latest/api.html#module-petastorm.reader
+  petastorm: {'cache_type' : 'local-disk',
+              'cache_location' : '.cache',
+              'cache_size_limit' : 10000000000, #10gb
+              'cache_row_size_estimate' : 512}
 
 pyspark:
   property: {'spark.logConf': 'true',
              'spark.driver.memory': '10g',
              'spark.sql.execution.arrow.pyspark.enabled': 'true'}
   coalesce: 2
+
 
 server:
   host: "0.0.0.0"

--- a/eva.yml
+++ b/eva.yml
@@ -5,8 +5,13 @@ core:
   mode: "debug" #release
 
 executor:
-  batch_size: 50
-  gpu_batch_size: 1
+  # batch_mem_size configures the number of rows processed by the execution engine in one iteration
+  # #rows = max(1, row_mem_size / batch_mem_size)
+  batch_mem_size: 300000000 # 300mb
+
+  # batch size used for gpu_operations
+  gpu_batch_size: 20
+
   gpus: {'130.207.125.60': [0]}
 storage:
   engine: "src.storage.petastorm_storage_engine.PetastormStorageEngine"

--- a/src/executor/disk_based_storage_executor.py
+++ b/src/executor/disk_based_storage_executor.py
@@ -33,7 +33,7 @@ class DiskStorageExecutor(AbstractStorageExecutor):
     def __init__(self, node: StoragePlan):
         super().__init__(node)
         self.storage = OpenCVReader(node.video,
-                                    batch_size=node.batch_size,
+                                    batch_mem_size=node.batch_mem_size,
                                     offset=node.offset)
 
     def validate(self):

--- a/src/executor/limit_executor.py
+++ b/src/executor/limit_executor.py
@@ -17,7 +17,6 @@ from typing import Iterator
 from src.models.storage.batch import Batch
 from src.executor.abstract_executor import AbstractExecutor
 from src.planner.limit_plan import LimitPlan
-from src.configuration.configuration_manager import ConfigurationManager
 
 
 class LimitExecutor(AbstractExecutor):
@@ -32,8 +31,6 @@ class LimitExecutor(AbstractExecutor):
     def __init__(self, node: LimitPlan):
         super().__init__(node)
         self._limit_count = node.limit_value
-        self.BATCH_MAX_SIZE = ConfigurationManager().get_value(
-            "executor", "batch_size")
 
     def validate(self):
         pass

--- a/src/executor/load_executor.py
+++ b/src/executor/load_executor.py
@@ -50,7 +50,8 @@ class LoadDataExecutor(AbstractExecutor):
         StorageEngine.create(self.node.table_metainfo)
         num_loaded_frames = 0
         video_reader = OpenCVReader(
-            os.path.join(self.path_prefix, self.node.file_path))
+            os.path.join(self.path_prefix, self.node.file_path),
+            batch_mem_size=self.node.batch_mem_size)
         for batch in video_reader.read():
             StorageEngine.write(self.node.table_metainfo, batch)
             num_loaded_frames += len(batch)

--- a/src/executor/storage_executor.py
+++ b/src/executor/storage_executor.py
@@ -28,4 +28,4 @@ class StorageExecutor(AbstractExecutor):
         pass
 
     def exec(self) -> Iterator[Batch]:
-        return StorageEngine.read(self.node.video)
+        return StorageEngine.read(self.node.video, self.node.batch_mem_size)

--- a/src/planner/load_data_plan.py
+++ b/src/planner/load_data_plan.py
@@ -26,12 +26,16 @@ class LoadDataPlan(AbstractPlan):
     Arguments:
         table_metainfo(DataFrameMetadata): table metadata info to load into
         file_path(Path): file path from where we will load the data
+        batch_mem_size(int): memory size of the batch loaded from disk
         """
 
-    def __init__(self, table_metainfo: DataFrameMetadata, file_path: Path):
+    def __init__(self,
+                 table_metainfo: DataFrameMetadata,
+                 file_path: Path, batch_mem_size: int):
         super().__init__(PlanOprType.LOAD_DATA)
         self._table_metainfo = table_metainfo
         self._file_path = file_path
+        self._batch_mem_size = batch_mem_size
 
     @property
     def table_metainfo(self):
@@ -41,7 +45,13 @@ class LoadDataPlan(AbstractPlan):
     def file_path(self):
         return self._file_path
 
+    @property
+    def batch_mem_size(self):
+        return self._batch_mem_size
+
     def __str__(self):
-        print_str = 'LoadDataPlan(table_id={},file_path={})'.format(
-            self.table_metainfo, self.file_path)
+        print_str = 'LoadDataPlan(table_id={}, file_path={}, \
+            batch_mem_size={})'.format(self.table_metainfo,
+                                       self.file_path,
+                                       self.batch_mem_size)
         return print_str

--- a/src/planner/storage_plan.py
+++ b/src/planner/storage_plan.py
@@ -15,7 +15,6 @@
 from src.catalog.models.df_metadata import DataFrameMetadata
 from src.planner.abstract_plan import AbstractPlan
 from src.planner.types import PlanOprType
-from src.configuration.configuration_manager import ConfigurationManager
 
 
 class StoragePlan(AbstractPlan):
@@ -25,7 +24,7 @@ class StoragePlan(AbstractPlan):
 
     Arguments:
         video (DataFrameMetadata): Required meta-data for fetching data
-        batch_mem_size (int): memory size of the batch retreived
+        batch_mem_size (int): memory size of the batch read from disk
         skip_frames (int): skip frequency
         offset (int): storage offset for retrieving data
         limit (int): limit on data records to be retrieved
@@ -33,17 +32,16 @@ class StoragePlan(AbstractPlan):
         curr_shard (int): current curr_shard if data is sharded
     """
 
-    def __init__(self, video: DataFrameMetadata, batch_mem_size: int = None,
-                 skip_frames: int = 0, offset: int = None, limit: int = None,
-                 total_shards: int = 0, curr_shard: int = 0):
+    def __init__(self, video: DataFrameMetadata,
+                 batch_mem_size: int,
+                 skip_frames: int = 0,
+                 offset: int = None,
+                 limit: int = None,
+                 total_shards: int = 0,
+                 curr_shard: int = 0):
         super().__init__(PlanOprType.STORAGE_PLAN)
         self._video = video
         self._batch_mem_size = batch_mem_size
-        if self._batch_mem_size is None:
-            self._batch_mem_size = ConfigurationManager(
-            ).get_value("executor", "batch_mem_size")
-            if self._batch_mem_size is None:
-                self._batch_mem_size = 300000000  # 300mb
         self._skip_frames = skip_frames
         self._offset = offset
         self._limit = limit

--- a/src/readers/abstract_reader.py
+++ b/src/readers/abstract_reader.py
@@ -16,10 +16,8 @@ from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Iterator, Dict
 import pandas as pd
-import sys
 
 from src.models.storage.batch import Batch
-from src.configuration.configuration_manager import ConfigurationManager
 
 
 class AbstractReader(metaclass=ABCMeta):
@@ -30,25 +28,18 @@ class AbstractReader(metaclass=ABCMeta):
 
     Attributes:
         file_url (str): path to read data from
-        batch_mem_size (int, optional): used to compute the #frames to
+        batch_mem_size (int): used to compute the #frames to
                                             read in batch from video
         offset (int, optional): Start frame location in video
         """
 
-    def __init__(self, file_url: str, batch_mem_size=None,
+    def __init__(self, file_url: str, batch_mem_size: int,
                  offset=None):
         # Opencv doesn't support pathlib.Path so convert to raw str
         if isinstance(file_url, Path):
             file_url = str(file_url)
-
         self.file_url = file_url
         self.batch_mem_size = batch_mem_size
-        if self.batch_mem_size is None or self.batch_mem_size < 0:
-            self.batch_mem_size = ConfigurationManager().get_value(
-                "executor",
-                "batch_mem_size")
-            if self.batch_mem_size is None:
-                self.batch_mem_size = 300000000  # 300mb
         self.offset = offset
 
     def read(self) -> Iterator[Batch]:
@@ -58,14 +49,12 @@ class AbstractReader(metaclass=ABCMeta):
         """
 
         data_batch = []
-        # Fetch batch_mem_size from Config if not provided
-
         row_size = None
         for data in self._read():
             if row_size is None:
-                row_size = sys.getsizeof(pd.DataFrame([data]))
+                row_size = data['data'].nbytes
             data_batch.append(data)
-            if len(data_batch) * row_size > self.batch_mem_size:
+            if len(data_batch) * row_size >= self.batch_mem_size:
                 yield Batch(pd.DataFrame(data_batch))
                 data_batch = []
         if data_batch:

--- a/src/storage/petastorm_storage_engine.py
+++ b/src/storage/petastorm_storage_engine.py
@@ -92,15 +92,19 @@ class PetastormStorageEngine(AbstractStorageEngine):
                 .mode('append') \
                 .parquet(self._spark_url(table))
 
-    def read(self, table: DataFrameMetadata, columns: List[
-            str] = None, predicate_func=None) -> Iterator[Batch]:
+    def read(self,
+             table: DataFrameMetadata,
+             batch_mem_size: int,
+             columns: List[str] = None,
+             predicate_func=None) -> Iterator[Batch]:
         """
         Reads the table and return a batch iterator for the
         tuples that passes the predicate func.
 
         Argument:
             table: table metadata object to write into
-            columns List[str]: A list of column names to be
+            batch_mem_size (int): memory size of the batch read from storage
+            columns (List[str]): A list of column names to be
                 considered in predicate_func
             predicate_func: customized predicate function returns bool
 
@@ -114,7 +118,9 @@ class PetastormStorageEngine(AbstractStorageEngine):
         # ToDo: Handle the sharding logic. We might have to maintain a
         # context for deciding which shard to read
         petastorm_reader = PetastormReader(
-            self._spark_url(table), predicate=predicate)
+            self._spark_url(table),
+            batch_mem_size=batch_mem_size,
+            predicate=predicate)
         for batch in petastorm_reader.read():
             yield batch
 

--- a/test/executor/test_disk_storage_executor.py
+++ b/test/executor/test_disk_storage_executor.py
@@ -28,7 +28,8 @@ class DiskStorageExecutorTest(unittest.TestCase):
         class_instance = mock_class.return_value
 
         video_info = DataFrameMetadata('dataset', 'dummy.avi')
-        storage_plan = StoragePlan(video_info)
+        batch_mem_size = 3000
+        storage_plan = StoragePlan(video_info, batch_mem_size)
 
         executor = DiskStorageExecutor(storage_plan)
 

--- a/test/executor/test_disk_storage_executor.py
+++ b/test/executor/test_disk_storage_executor.py
@@ -36,7 +36,8 @@ class DiskStorageExecutorTest(unittest.TestCase):
         actual = list(executor.exec())
 
         mock_class.assert_called_once_with(video_info,
-                                           batch_size=storage_plan.batch_size,
+                                           batch_mem_size=(
+                                               storage_plan.batch_mem_size),
                                            limit=storage_plan.limit,
                                            offset=storage_plan.offset,
                                            skip_frames=(

--- a/test/executor/test_load_executor.py
+++ b/test/executor/test_load_executor.py
@@ -35,13 +35,17 @@ class LoadExecutorTest(unittest.TestCase):
         cv_mock.return_value = MagicMock(**attrs)
         file_path = 'video'
         table_metainfo = 'info'
+        batch_mem_size = 3000
         plan = type(
             "LoadDataPlan", (), {
-                'file_path': file_path, 'table_metainfo': table_metainfo})
+                'file_path': file_path,
+                'table_metainfo': table_metainfo,
+                'batch_mem_size': batch_mem_size})
 
         load_executor = LoadDataExecutor(plan)
         batch = next(load_executor.exec())
-        cv_mock.assert_called_once_with(os.path.join(PATH_PREFIX, file_path))
+        cv_mock.assert_called_once_with(os.path.join(PATH_PREFIX, file_path),
+                                        batch_mem_size=batch_mem_size)
         create_mock.assert_called_once_with(table_metainfo)
         write_mock.has_calls(call(table_metainfo, batch_frames[0]), call(
             table_metainfo, batch_frames[1]))

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -108,7 +108,7 @@ class PlanExecutorTest(unittest.TestCase):
         self.assertIsInstance(executor, CreateUDFExecutor)
 
         # LoadDataExecutor
-        plan = LoadDataPlan(MagicMock(), MagicMock())
+        plan = LoadDataPlan(MagicMock(), MagicMock(), MagicMock())
         executor = PlanExecutor(plan)._build_execution_tree(plan)
         self.assertIsInstance(executor, LoadDataExecutor)
 
@@ -198,7 +198,7 @@ class PlanExecutorTest(unittest.TestCase):
         # LoadDataExecutor
         mock_build.reset_mock()
         mock_clean.reset_mock()
-        tree = MagicMock(node=LoadDataPlan(None, None))
+        tree = MagicMock(node=LoadDataPlan(None, None, None))
         mock_build.return_value = tree
         actual = list(PlanExecutor(None).execute_plan())
         tree.exec.assert_called_once()
@@ -234,7 +234,7 @@ class PlanExecutorTest(unittest.TestCase):
             batch_1,
             batch_2])
 
-        storage_plan = StoragePlan(video)
+        storage_plan = StoragePlan(video, batch_mem_size=3000)
         seq_scan = SeqScanPlan(predicate=dummy_expr, column_ids=[])
         seq_scan.append_child(storage_plan)
 

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -39,7 +39,9 @@ class LoadExecutorTest(unittest.TestCase):
 
         metadata = CatalogManager().get_dataset_metadata("", "MyVideo")
         actual_batch = Batch(pd.DataFrame())
-        actual_batch = Batch.concat(StorageEngine.read(metadata), copy=False)
+        actual_batch = Batch.concat(StorageEngine.read(metadata,
+                                                       batch_mem_size=3000),
+                                    copy=False)
         actual_batch.sort()
         expected_batch = list(create_dummy_batches())
         self.assertEqual([actual_batch], expected_batch)

--- a/test/planner/test_plan.py
+++ b/test/planner/test_plan.py
@@ -80,12 +80,16 @@ class PlanNodeTests(unittest.TestCase):
     def test_load_data_plan(self):
         table_metainfo = 'meta_info'
         file_path = 'test.mp4'
-        plan_str = 'LoadDataPlan(table_id={},file_path={})'.format(
-            table_metainfo, file_path)
-        plan = LoadDataPlan(table_metainfo, file_path)
+        batch_mem_size = 3000
+        plan_str = 'LoadDataPlan(table_id={}, file_path={}, \
+            batch_mem_size={})'.format(table_metainfo,
+                                       file_path,
+                                       batch_mem_size)
+        plan = LoadDataPlan(table_metainfo, file_path, batch_mem_size)
         self.assertEqual(plan.opr_type, PlanOprType.LOAD_DATA)
         self.assertEqual(plan.table_metainfo, table_metainfo)
         self.assertEqual(plan.file_path, file_path)
+        self.assertEqual(plan.batch_mem_size, batch_mem_size)
         self.assertEqual(str(plan), plan_str)
 
     def test_upload_plan(self):

--- a/test/readers/test_opencv_reader.py
+++ b/test/readers/test_opencv_reader.py
@@ -42,7 +42,7 @@ class VideoLoaderTest(unittest.TestCase):
     def test_should_return_batches_equivalent_to_number_of_frames(self):
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
-            batch_size=1)
+            batch_mem_size=1)
         batches = list(video_loader.read())
         expected = list(create_dummy_batches(batch_size=1))
         self.assertTrue(batches, expected)
@@ -50,7 +50,7 @@ class VideoLoaderTest(unittest.TestCase):
     def test_should_return_one_batches_for_negative_size(self):
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
-            batch_size=-1)
+            batch_mem_size=-1)
         batches = list(video_loader.read())
         expected = list(create_dummy_batches())
         self.assertTrue(batches, expected)
@@ -69,7 +69,7 @@ class VideoLoaderTest(unittest.TestCase):
             self):
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
-            batch_size=NUM_FRAMES,
+            batch_mem_size=NUM_FRAMES,
             offset=2)
         batches = list(video_loader.read())
         expected = list(create_dummy_batches(
@@ -79,7 +79,7 @@ class VideoLoaderTest(unittest.TestCase):
     def test_should_start_frame_number_from_two(self):
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
-            batch_size=NUM_FRAMES,
+            batch_mem_size=NUM_FRAMES,
             start_frame_id=2)
         batches = list(video_loader.read())
         expected = list(create_dummy_batches(
@@ -89,7 +89,7 @@ class VideoLoaderTest(unittest.TestCase):
     def test_should_start_frame_number_from_two_and_offset_from_one(self):
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
-            batch_size=NUM_FRAMES,
+            batch_mem_size=NUM_FRAMES,
             offset=1,
             start_frame_id=2)
         batches = list(video_loader.read())
@@ -98,11 +98,11 @@ class VideoLoaderTest(unittest.TestCase):
         self.assertTrue(batches, expected)
 
     @patch('src.readers.abstract_reader.ConfigurationManager.get_value')
-    def test_should_work_if_batch_size_not_in_config(self, get_val_mock):
+    def test_should_work_if_batch_mem_size_not_in_config(self, get_val_mock):
+        get_val_mock.return_value = None
         video_loader = OpenCVReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'))
-        get_val_mock.return_value = None
         batches = list(video_loader.read())
         expected = list(create_dummy_batches())
         self.assertTrue(batches, expected)
-        get_val_mock.assert_called_once_with("executor", "batch_size")
+        get_val_mock.assert_called_once_with("executor", "batch_mem_size")

--- a/test/readers/test_petastorm_reader.py
+++ b/test/readers/test_petastorm_reader.py
@@ -18,6 +18,7 @@ import os
 import numpy as np
 
 from src.readers.petastorm_reader import PetastormReader
+from src.configuration.configuration_manager import ConfigurationManager
 
 from test.util import PATH_PREFIX
 
@@ -58,7 +59,11 @@ class PetastormLoaderTest(unittest.TestCase):
             os.path.join(PATH_PREFIX, 'dummy.avi'),
             shard_count=3,
             cur_shard=2,
-            predicate='pred')
+            predicate='pred',
+            cache_type=None,
+            cache_location=None,
+            cache_size_limit=None,
+            cache_row_size_estimate=None)
 
     @patch("src.readers.petastorm_reader.make_reader")
     def test_should_call_petastorm_make_reader_with_negative_shards(self,
@@ -68,11 +73,18 @@ class PetastormLoaderTest(unittest.TestCase):
             cur_shard=-1,
             shard_count=-2)
         list(petastorm_reader._read())
+        petastorm_config = ConfigurationManager().get_value('storage',
+                                                            'petastorm')
         mock.assert_called_once_with(
             os.path.join(PATH_PREFIX, 'dummy.avi'),
             shard_count=None,
             cur_shard=None,
-            predicate=None)
+            predicate=None,
+            cache_location=petastorm_config.get('cache_location', None),
+            cache_row_size_estimate=petastorm_config.get(
+                'cache_row_size_estimate', None),
+            cache_size_limit=petastorm_config.get('cache_size_limit', None),
+            cache_type=petastorm_config.get('cache_type', None))
 
     @patch("src.readers.petastorm_reader.make_reader")
     def test_should_read_data_using_petastorm_reader(self, mock):

--- a/test/readers/test_petastorm_reader.py
+++ b/test/readers/test_petastorm_reader.py
@@ -51,6 +51,7 @@ class PetastormLoaderTest(unittest.TestCase):
                                                                    mock):
         petastorm_reader = PetastormReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
+            batch_mem_size=3000,
             cur_shard=2,
             shard_count=3,
             predicate='pred')
@@ -70,6 +71,7 @@ class PetastormLoaderTest(unittest.TestCase):
                                                                     mock):
         petastorm_reader = PetastormReader(
             file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
+            batch_mem_size=3000,
             cur_shard=-1,
             shard_count=-2)
         list(petastorm_reader._read())
@@ -89,7 +91,8 @@ class PetastormLoaderTest(unittest.TestCase):
     @patch("src.readers.petastorm_reader.make_reader")
     def test_should_read_data_using_petastorm_reader(self, mock):
         petastorm_reader = PetastormReader(
-            file_url=os.path.join(PATH_PREFIX, 'dummy.avi'))
+            file_url=os.path.join(PATH_PREFIX, 'dummy.avi'),
+            batch_mem_size=3000)
         dummy_values = map(lambda i: self.DummyRow(
             i, np.ones((2, 2, 3)) * i), range(3))
         mock.return_value = self.DummyReader(dummy_values)

--- a/test/storage/test_petastorm_storage_engine.py
+++ b/test/storage/test_petastorm_storage_engine.py
@@ -51,7 +51,7 @@ class PetastormStorageEngineTest(unittest.TestCase):
     def test_should_create_empty_table(self):
         petastorm = PetastormStorageEngine()
         petastorm.create(self.table)
-        records = list(petastorm.read(self.table))
+        records = list(petastorm.read(self.table, batch_mem_size=3000))
         self.assertEqual(records, [])
 
     def test_should_write_rows_to_table(self):
@@ -62,7 +62,7 @@ class PetastormStorageEngineTest(unittest.TestCase):
         for batch in dummy_batches:
             petastorm.write(self.table, batch)
 
-        read_batch = list(petastorm.read(self.table))
+        read_batch = list(petastorm.read(self.table, batch_mem_size=3000))
         self.assertTrue(read_batch, dummy_batches)
 
     def test_should_return_even_frames(self):
@@ -76,8 +76,9 @@ class PetastormStorageEngineTest(unittest.TestCase):
         read_batch = list(
             petastorm.read(
                 self.table,
-                ["id"],
-                lambda id: id %
+                batch_mem_size=3000,
+                columns=["id"],
+                predicate_func=lambda id: id %
                 2 == 0))
         expected_batch = list(create_dummy_batches(
             filters=[

--- a/test/util.py
+++ b/test/util.py
@@ -27,6 +27,7 @@ from src.configuration.configuration_manager import ConfigurationManager
 
 
 NUM_FRAMES = 10
+FRAME_SIZE = 2 * 2 * 3
 CONFIG = ConfigurationManager()
 PATH_PREFIX = CONFIG.get_value('storage', 'path_prefix')
 


### PR DESCRIPTION
1. Enabled petastorm caching to speed up data loading.
2. Changed batch_size to batch_mem_size. Rather than using a fixed size batch during execution, Eva infers the batch size based on the video data. The idea is that the number of video frames proceeded together should be configured based on the frame size rather than using a fixed number for all videos.