### PR TITLE
Support for loading datasets

### DIFF
--- a/eva/executor/create_executor.py
+++ b/eva/executor/create_executor.py
@@ -34,11 +34,28 @@ class CreateExecutor(AbstractExecutor):
         Calls the catalog to create metadata corresponding to the table.
         Calls the storage to create a spark dataframe from the metadata object.
         """
-        if (self.node.if_not_exists):
-            # check catalog if we already have this table
-            return
 
-        table_name = self.node.video_ref.table_info.table_name
+        if (self.node.if_not_exists):
+            
+            # check if the table exists
+            catalog_manager = CatalogManager()
+
+            # TODO: Due to the way get_table_bindings is written, 
+            # an error will be logged here if the table does not exist. 
+            # But that is okay since we are just checking if the table exists. 
+            table_name = self.node.video_ref.table_name
+            metadata_id, _ = catalog_manager.get_table_bindings("eva_catalog",
+                                                                table_name)
+
+            # metadata_id is not None when the table exists, so return
+            if metadata_id is not None:
+                return
+
+        # TODO: I had to comment out the following line,
+        # because it was causing an error. table_name is in video_ref, 
+        # and not in table_info.
+        # table_name = self.node.video_ref.table_info.table_name
+        table_name = self.node.video_ref.table_name
         file_url = str(generate_file_path(table_name))
         metadata = CatalogManager().create_metadata(table_name,
                                                     file_url,

--- a/eva/executor/load_csv_executor.py
+++ b/eva/executor/load_csv_executor.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pandas as pd
+
+from eva.configuration.configuration_manager import ConfigurationManager
+from eva.executor.abstract_executor import AbstractExecutor
+from eva.models.storage.batch import Batch
+from eva.planner.load_data_plan import LoadDataPlan
+from eva.storage.storage_engine import StorageEngine
+from eva.readers.csv_reader import CSVReader
+
+
+class LoadCSVExecutor(AbstractExecutor):
+
+    def __init__(self, node: LoadDataPlan):
+        super().__init__(node)
+        config = ConfigurationManager()
+        self.path_prefix = config.get_value('storage', 'path_prefix')
+
+    def validate(self):
+        pass
+
+    def exec(self):
+        """
+        Read the input meta file using pandas and persist data
+        using storage engine
+        """
+
+        # Read the CSV file
+        # converters is a dictionary of functions that convert the values
+        # in the column to the desired type
+        csv_reader = CSVReader(
+            os.path.join(self.path_prefix, self.node.file_path),
+            column_list=self.node.column_list,
+            batch_mem_size=self.node.batch_mem_size
+        )
+
+        # write with storage engine in batches
+        num_loaded_frames = 0
+        for batch in csv_reader.read():
+            StorageEngine.write(self.node.table_metainfo, batch)
+            num_loaded_frames += len(batch)
+
+        # yield result
+        df_yield_result = Batch(
+            pd.DataFrame({
+                'CSV': str(self.node.file_path),
+                'Number of loaded frames': num_loaded_frames
+            }, index=[0]))
+
+        yield df_yield_result

--- a/eva/executor/load_executor.py
+++ b/eva/executor/load_executor.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import pandas as pd
-
-from eva.planner.load_data_plan import LoadDataPlan
-from eva.executor.abstract_executor import AbstractExecutor
-from eva.storage.storage_engine import StorageEngine
-from eva.readers.opencv_reader import OpenCVReader
-from eva.models.storage.batch import Batch
 from eva.configuration.configuration_manager import ConfigurationManager
+from eva.executor.abstract_executor import AbstractExecutor
+from eva.executor.load_csv_executor import LoadCSVExecutor
+from eva.executor.load_video_executor import LoadVideoExecutor
+from eva.planner.load_data_plan import LoadDataPlan
+from eva.parser.types import FileFormatType
 
 
 class LoadDataExecutor(AbstractExecutor):
@@ -36,26 +33,17 @@ class LoadDataExecutor(AbstractExecutor):
 
     def exec(self):
         """
-        Read the input video using opencv and persist data
-        using storage engine
+        Use TYPE to determine the type of data to load.
         """
 
-        # videos are persisted using (id, data) schema where id = frame_id
-        # and data = frame_data. Current logic supports loading a video into
-        # storage with the assumption that frame_id starts from 0. In case
-        # we want to append to the existing store we have to figure out the
-        # correct frame_id. It can also be a parameter based by the user.
+        # invoke the appropriate executor
+        if self.node.file_options['file_format'] == FileFormatType.VIDEO:
+            executor = LoadVideoExecutor(self.node)
+        elif self.node.file_options['file_format'] == FileFormatType.CSV:
+            executor = LoadCSVExecutor(self.node)
 
-        # We currently use create to empty existing table.
-        StorageEngine.create(self.node.table_metainfo)
-        num_loaded_frames = 0
-        video_reader = OpenCVReader(
-            os.path.join(self.path_prefix, self.node.file_path),
-            batch_mem_size=self.node.batch_mem_size)
-        for batch in video_reader.read():
-            StorageEngine.write(self.node.table_metainfo, batch)
-            num_loaded_frames += len(batch)
+        # for each batch, exec the executor
+        for batch in executor.exec():
+            yield batch
 
-        yield Batch(pd.DataFrame({'Video': str(self.node.file_path),
-                                  'Num Loaded Frames': num_loaded_frames},
-                                 index=[0]))
+

--- a/eva/executor/load_video_executor.py
+++ b/eva/executor/load_video_executor.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pandas as pd
+
+from eva.configuration.configuration_manager import ConfigurationManager
+from eva.executor.abstract_executor import AbstractExecutor
+from eva.models.storage.batch import Batch
+from eva.planner.load_data_plan import LoadDataPlan
+from eva.readers.opencv_reader import OpenCVReader
+from eva.storage.storage_engine import StorageEngine
+
+
+class LoadVideoExecutor(AbstractExecutor):
+
+    def __init__(self, node: LoadDataPlan):
+        super().__init__(node)
+        config = ConfigurationManager()
+        self.path_prefix = config.get_value('storage', 'path_prefix')
+
+    def validate(self):
+        pass
+
+    def exec(self):
+        """
+        Read the input video using opencv and persist data
+        using storage engine
+        """
+        
+        # We currently use create to empty existing table.
+        StorageEngine.create(self.node.table_metainfo)
+
+        # read the video with opencv
+        video_reader = OpenCVReader(
+            os.path.join(self.path_prefix, self.node.file_path),
+            batch_mem_size=self.node.batch_mem_size)
+
+        # write with storage engine in batches
+        num_loaded_frames = 0
+        for batch in video_reader.read():
+            StorageEngine.write(self.node.table_metainfo, batch)
+            num_loaded_frames += len(batch)
+
+        # yield result
+        df_yield_result = Batch(
+            pd.DataFrame({
+                'Video': str(self.node.file_path),
+                'Num Loaded Frames': num_loaded_frames
+            }, index=[0]))
+
+        yield df_yield_result

--- a/eva/optimizer/operators.py
+++ b/eva/optimizer/operators.py
@@ -456,10 +456,14 @@ class LogicalLoadData(Operator):
     """
 
     def __init__(self, table_metainfo: DataFrameMetadata,
-                 path: Path, children=None):
+                 path: Path, 
+                 column_list: List[AbstractExpression] = None,
+                 file_options: dict = None, children=None):
         super().__init__(OperatorType.LOGICALLOADDATA, children=children)
         self._table_metainfo = table_metainfo
         self._path = path
+        self._column_list = column_list
+        self._file_options = file_options
 
     @property
     def table_metainfo(self):
@@ -469,9 +473,21 @@ class LogicalLoadData(Operator):
     def path(self):
         return self._path
 
+    @property
+    def column_list(self):
+        return self._column_list
+
+    @property
+    def file_options(self):
+        return self._file_options
+
     def __str__(self):
-        return 'LogicalLoadData(table: {}, path: {})'.format(
-            self.table_metainfo, self.path)
+        return "LogicalLoadData(table: {}, path: {}, \
+                column_list: {}, \
+                file_options: {})".format(self.table_metainfo, 
+                                          self.path, 
+                                          self.column_list, 
+                                          self.file_options)
 
     def __eq__(self, other):
         is_subtree_equal = super().__eq__(other)
@@ -479,7 +495,9 @@ class LogicalLoadData(Operator):
             return False
         return (is_subtree_equal
                 and self.table_metainfo == other.table_metainfo
-                and self.path == other.path)
+                and self.path == other.path
+                and self.column_list == other.column_list
+                and self.file_options == other.file_options)
 
 
 class LogicalUpload(Operator):

--- a/eva/optimizer/rules/rules.py
+++ b/eva/optimizer/rules/rules.py
@@ -414,7 +414,10 @@ class LogicalLoadToPhysical(Rule):
         if config_batch_mem_size:
             batch_mem_size = config_batch_mem_size
         after = LoadDataPlan(before.table_metainfo,
-                             before.path, batch_mem_size)
+                             before.path, 
+                             batch_mem_size,
+                             before.column_list,
+                             before.file_options)
         return after
 
 

--- a/eva/optimizer/statement_to_opr_convertor.py
+++ b/eva/optimizer/statement_to_opr_convertor.py
@@ -35,6 +35,7 @@ from eva.optimizer.optimizer_utils import (bind_table_ref, bind_columns_expr,
                                            create_video_metadata)
 from eva.parser.table_ref import TableRef
 from eva.utils.logging_manager import LoggingLevel, LoggingManager
+from eva.expression.tuple_value_expression import TupleValueExpression
 
 
 class StatementToPlanConvertor:
@@ -223,7 +224,30 @@ class StatementToPlanConvertor:
             # Create a new metadata object
             table_metainfo = create_video_metadata(table_ref.table.table_name)
 
-        load_data_opr = LogicalLoadData(table_metainfo, statement.path)
+        # populate self._column_map
+        self._populate_column_map(table_metainfo)
+        
+        # if query had columns specified, we just copy them
+        if statement.column_list is not None:
+            column_list = statement.column_list
+        
+        # else we curate the column list from the metadata
+        else:
+            column_list = []
+            for column in table_metainfo.columns:
+                column_list.append(
+                    TupleValueExpression(
+                        col_name=column.name,
+                        table_name=table_metainfo.name, 
+                        col_object=column))
+        
+        # bind the columns
+        bind_columns_expr(column_list, self._column_map)
+        
+        load_data_opr = LogicalLoadData(table_metainfo, 
+                                        statement.path, 
+                                        column_list,
+                                        statement.file_options)
         self._plan = load_data_opr
 
     def visit_upload(self, statement: UploadStatement):

--- a/eva/parser/evaql/evaql_lexer.g4
+++ b/eva/parser/evaql/evaql_lexer.g4
@@ -84,6 +84,12 @@ VALUES:                              'VALUES';
 WHERE:                               'WHERE';
 XOR:                                 'XOR';
 
+// File Formats
+WITH:                 'WITH';
+FORMAT:               'FORMAT';
+CSV:                  'CSV';
+VIDEO:                'VIDEO';
+
 // EVAQL keywords
 
 ERROR_BOUNDS:						 'ERROR_WITHIN';

--- a/eva/parser/evaql/evaql_parser.g4
+++ b/eva/parser/evaql/evaql_parser.g4
@@ -154,10 +154,19 @@ updateStatement
     : singleUpdateStatement
     ;
 
+
 loadStatement
     : LOAD DATA
       INFILE fileName
       INTO tableName
+        (
+            ('(' columns=uidList ')')
+        )?
+      (WITH fileOptions)?
+    ;
+
+fileOptions
+    : FORMAT fileFormat=(CSV|VIDEO)
     ;
 
 uploadStatement

--- a/eva/parser/load_statement.py
+++ b/eva/parser/load_statement.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 from eva.parser.statement import AbstractStatement
-
+from eva.expression.abstract_expression import AbstractExpression
 from eva.parser.types import StatementType
 from eva.parser.table_ref import TableRef
 from pathlib import Path
+from typing import List
 
 
 class LoadDataStatement(AbstractStatement):
@@ -29,14 +30,20 @@ class LoadDataStatement(AbstractStatement):
     path (str): path from where data needs to be loaded
     """
 
-    def __init__(self, table: TableRef, path: str):
+    def __init__(self, 
+                 table: TableRef,
+                 path: str,
+                 column_list: List[AbstractExpression] = None,
+                 file_options: dict = None):
         super().__init__(StatementType.LOAD_DATA)
         self._table = table
         self._path = Path(path)
+        self._column_list = column_list
+        self._file_options = file_options
 
     def __str__(self) -> str:
-        print_str = "LOAD DATA INFILE {} INTO {}".format(
-            self._path.name, self._table)
+        print_str = "LOAD DATA INFILE {} INTO {}({})".format(
+            self._path.name, self._table, self._column_list)
         return print_str
 
     @property
@@ -47,8 +54,18 @@ class LoadDataStatement(AbstractStatement):
     def path(self) -> Path:
         return self._path
 
+    @property
+    def column_list(self) -> List[AbstractExpression]:
+        return self._column_list
+
+    @property
+    def file_options(self) -> dict:
+        return self._file_options
+
     def __eq__(self, other):
         if not isinstance(other, LoadDataStatement):
             return False
         return (self.table == other.table
-                and self.path == other.path)
+                and self.path == other.path
+                and self.column_list == other.column_list
+                and self.file_options == other.file_options)

--- a/eva/parser/parser_visitor/_load_statement.py
+++ b/eva/parser/parser_visitor/_load_statement.py
@@ -18,11 +18,39 @@ from eva.parser.evaql.evaql_parserVisitor import evaql_parserVisitor
 from eva.parser.evaql.evaql_parser import evaql_parser
 
 from eva.parser.table_ref import TableRef
+from eva.parser.types import FileFormatType
 
 
 class Load(evaql_parserVisitor):
     def visitLoadStatement(self, ctx: evaql_parser.LoadStatementContext):
         file_path = self.visit(ctx.fileName()).value
         table = TableRef(self.visit(ctx.tableName()))
-        stmt = LoadDataStatement(table, file_path)
+
+        # Set default for file_format as Video
+        file_format = FileFormatType.VIDEO
+        file_options = {}
+        file_options['file_format'] = file_format
+
+        if ctx.fileOptions():
+            file_options = self.visit(ctx.fileOptions())
+
+        # set default for column_list as None
+        column_list = None
+        if ctx.uidList():
+            column_list = self.visit(ctx.uidList())
+
+        stmt = LoadDataStatement(table, file_path, column_list, 
+                                 file_options)
         return stmt
+
+    def visitFileOptions(self, ctx: evaql_parser.FileOptionsContext):
+        file_format = FileFormatType.VIDEO
+        # Check the file format 
+        if ctx.CSV() is not None:
+            file_format = FileFormatType.CSV
+
+        # parse and add more file options in future
+        file_options = {}
+        file_options['file_format'] = file_format
+
+        return file_options

--- a/eva/parser/types.py
+++ b/eva/parser/types.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from enum import IntEnum, unique
+from enum import IntEnum, unique, Enum, auto
 
 
 class ColumnConstraintEnum(IntEnum):
@@ -43,3 +43,12 @@ class ParserOrderBySortType(IntEnum):
     """
     ASC = 1
     DESC = 2
+
+
+@unique
+class FileFormatType(Enum):
+    """
+    Manages enums for all order by sort types
+    """
+    VIDEO = auto()
+    CSV = auto()

--- a/eva/planner/load_data_plan.py
+++ b/eva/planner/load_data_plan.py
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from eva.expression.abstract_expression import AbstractExpression
 from eva.planner.abstract_plan import AbstractPlan
 from eva.planner.types import PlanOprType
 from pathlib import Path
 from eva.catalog.models.df_metadata import DataFrameMetadata
+from typing import List
 
 
 class LoadDataPlan(AbstractPlan):
@@ -30,12 +32,16 @@ class LoadDataPlan(AbstractPlan):
         """
 
     def __init__(self,
-                 table_metainfo: DataFrameMetadata,
-                 file_path: Path, batch_mem_size: int):
+                 table_metainfo: DataFrameMetadata, file_path: Path,
+                 batch_mem_size: int,
+                 column_list: List[AbstractExpression] = None,
+                 file_options: dict = None):
         super().__init__(PlanOprType.LOAD_DATA)
         self._table_metainfo = table_metainfo
         self._file_path = file_path
         self._batch_mem_size = batch_mem_size
+        self._column_list = column_list
+        self._file_options = file_options
 
     @property
     def table_metainfo(self):
@@ -49,9 +55,21 @@ class LoadDataPlan(AbstractPlan):
     def batch_mem_size(self):
         return self._batch_mem_size
 
+    @property
+    def column_list(self):
+        return self._column_list
+
+    @property
+    def file_options(self):
+        return self._file_options
+
     def __str__(self):
         print_str = 'LoadDataPlan(table_id={}, file_path={}, \
-            batch_mem_size={})'.format(self.table_metainfo,
-                                       self.file_path,
-                                       self.batch_mem_size)
+            batch_mem_size={}, \
+            column_list={}, \
+            file_options={})'.format(self.table_metainfo,
+                                     self.file_path,
+                                     self.batch_mem_size,
+                                     self.column_list,
+                                     self.file_options)
         return print_str

--- a/eva/readers/abstract_reader.py
+++ b/eva/readers/abstract_reader.py
@@ -52,7 +52,10 @@ class AbstractReader(metaclass=ABCMeta):
         row_size = None
         for data in self._read():
             if row_size is None:
-                row_size = data['data'].nbytes
+                if 'data' in data:
+                    row_size = data['data'].nbytes
+                else:
+                    row_size = 1
             data_batch.append(data)
             if len(data_batch) * row_size >= self.batch_mem_size:
                 yield Batch(pd.DataFrame(data_batch))

--- a/eva/readers/csv_reader.py
+++ b/eva/readers/csv_reader.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+from typing import Iterator, Dict
+
+from eva.readers.abstract_reader import AbstractReader
+from eva.utils.logging_manager import LoggingLevel
+from eva.utils.logging_manager import LoggingManager
+
+
+class CSVReader(AbstractReader):
+
+    def __init__(self, *args, column_list, **kwargs):
+        """
+            Reads a CSV file and yields frame data.
+            Args:
+                column_list: list of columns (TupleValueExpression) 
+                to read from the CSV file
+        """
+
+        self._column_list = column_list
+        super().__init__(*args, **kwargs)
+
+    def _read(self) -> Iterator[Dict]:
+        
+        # TODO: What is a good location to put this code?
+        def convert_csv_string_to_ndarray(row_string):
+            """
+            Conver a string of comma seperated values to a numpy 
+            float array
+            """
+            return np.array(
+                [np.float32(val) for val in row_string.split(",")])
+        
+        LoggingManager().log("Reading CSV frames", LoggingLevel.INFO)
+
+        # TODO: Need to add strong sanity checks on the columns.
+
+        # read the csv in chunks, and only keep the columns we need
+        col_list_names = [col.col_name for col in self._column_list]
+        col_map = {col.col_name: col for col in self._column_list}
+        for chunk in pd.read_csv(self.file_url, chunksize=512,
+                                 usecols=col_list_names):
+
+            # apply the required conversions
+            for col in chunk.columns:
+
+                # TODO: Is there a better way to do this?
+                if (isinstance(chunk[col].iloc[0], str) and 
+                        col_map[col].col_object.type.name == 'NDARRAY'):
+
+                    # convert the string to a numpy array
+                    chunk[col] =\
+                        chunk[col].apply(convert_csv_string_to_ndarray)
+
+            # yield the chunk
+            for chunk_index, chunk_row in chunk.iterrows():
+                yield chunk_row

--- a/test/executor/test_load_executor.py
+++ b/test/executor/test_load_executor.py
@@ -13,41 +13,85 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-import os
 import pandas as pd
 
-from mock import patch, MagicMock, call
+from mock import patch, call
 from eva.executor.load_executor import LoadDataExecutor
 from eva.models.storage.batch import Batch
-
-from test.util import PATH_PREFIX
+from eva.parser.types import FileFormatType
+from test.util import create_sample_csv, file_remove
+from eva.expression.tuple_value_expression import TupleValueExpression
 
 
 class LoadExecutorTest(unittest.TestCase):
 
-    @patch('eva.executor.load_executor.OpenCVReader')
-    @patch('eva.executor.load_executor.StorageEngine.create')
-    @patch('eva.executor.load_executor.StorageEngine.write')
+    @patch('eva.storage.storage_engine.StorageEngine.create')
+    @patch('eva.storage.storage_engine.StorageEngine.write')
     def test_should_call_opencv_reader_and_storage_engine(
-            self, write_mock, create_mock, cv_mock):
+            self, write_mock, create_mock):
         batch_frames = [list(range(5))] * 2
-        attrs = {'read.return_value': batch_frames}
-        cv_mock.return_value = MagicMock(**attrs)
         file_path = 'video'
         table_metainfo = 'info'
         batch_mem_size = 3000
+        file_options = {}
+        file_options['file_format'] = FileFormatType.VIDEO
+        column_list = None
         plan = type(
             "LoadDataPlan", (), {
-                'file_path': file_path,
                 'table_metainfo': table_metainfo,
-                'batch_mem_size': batch_mem_size})
+                'file_path': file_path,
+                'batch_mem_size': batch_mem_size,
+                'column_list': column_list,
+                'file_options': file_options})
 
         load_executor = LoadDataExecutor(plan)
         batch = next(load_executor.exec())
-        cv_mock.assert_called_once_with(os.path.join(PATH_PREFIX, file_path),
-                                        batch_mem_size=batch_mem_size)
         create_mock.assert_called_once_with(table_metainfo)
         write_mock.has_calls(call(table_metainfo, batch_frames[0]), call(
             table_metainfo, batch_frames[1]))
+        # Note: We call exec() from the child classes.
         self.assertEqual(batch, Batch(pd.DataFrame(
-            [{'Video': file_path, 'Num Loaded Frames': 10}])))
+            [{'Video': file_path, 'Num Loaded Frames': 0}])))
+
+    @patch('eva.storage.storage_engine.StorageEngine.write')
+    def test_should_call_csv_reader_and_storage_engine(
+            self, write_mock):
+        batch_frames = [list(range(5))] * 2
+
+        # creates a dummy.csv
+        create_sample_csv()
+
+        file_path = 'dummy.csv'
+        table_metainfo = 'info'
+        batch_mem_size = 3000
+        file_options = {}
+        file_options['file_format'] = FileFormatType.CSV
+        column_list = [
+            TupleValueExpression(col_name='id', table_name='dummy'),
+            TupleValueExpression(col_name='frame_id', table_name='dummy'),
+            TupleValueExpression(col_name='video_id', table_name='dummy')
+        ]
+        plan = type(
+            "LoadDataPlan", (), {
+                'table_metainfo': table_metainfo,
+                'file_path': file_path,
+                'batch_mem_size': batch_mem_size,
+                'column_list': column_list,
+                'file_options': file_options})
+
+        load_executor = LoadDataExecutor(plan)
+        batch = next(load_executor.exec())
+        write_mock.has_calls(call(table_metainfo, batch_frames[0]), call(
+            table_metainfo, batch_frames[1]))
+
+        # Note: We call exec() from the child classes.
+        self.assertEqual(batch, Batch(pd.DataFrame(
+            [{'CSV': file_path, 'Number of loaded frames': 20}])))
+
+        # remove the dummy.csv
+        file_remove('dummy.csv')
+        
+
+        
+
+

--- a/test/executor/test_plan_executor.py
+++ b/test/executor/test_plan_executor.py
@@ -108,7 +108,8 @@ class PlanExecutorTest(unittest.TestCase):
         self.assertIsInstance(executor, CreateUDFExecutor)
 
         # LoadDataExecutor
-        plan = LoadDataPlan(MagicMock(), MagicMock(), MagicMock())
+        plan = LoadDataPlan(MagicMock(), MagicMock(), MagicMock(),
+                            MagicMock(), MagicMock())
         executor = PlanExecutor(plan)._build_execution_tree(plan)
         self.assertIsInstance(executor, LoadDataExecutor)
 
@@ -198,7 +199,8 @@ class PlanExecutorTest(unittest.TestCase):
         # LoadDataExecutor
         mock_build.reset_mock()
         mock_clean.reset_mock()
-        tree = MagicMock(node=LoadDataPlan(None, None, None))
+        tree = MagicMock(node=LoadDataPlan(None, None, None, None, 
+                                           None))
         mock_build.return_value = tree
         actual = list(PlanExecutor(None).execute_plan())
         tree.exec.assert_called_once()

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -19,7 +19,9 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.storage.storage_engine import StorageEngine
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import create_sample_video, create_dummy_batches, file_remove
+from test.util import create_sample_video, create_sample_csv
+from test.util import create_dummy_batches, create_dummy_csv_batches
+from test.util import file_remove
 
 
 class LoadExecutorTest(unittest.TestCase):
@@ -28,13 +30,16 @@ class LoadExecutorTest(unittest.TestCase):
         # reset the catalog manager before running each test
         CatalogManager().reset()
         create_sample_video()
+        create_sample_csv()
 
     def tearDown(self):
         file_remove('dummy.avi')
+        file_remove('dummy.csv')
 
-    # integration test
+    # integration test for video
     def test_should_load_video_in_table(self):
-        query = """LOAD DATA INFILE 'dummy.avi' INTO MyVideo;"""
+        query = """LOAD DATA INFILE 'dummy.avi' INTO MyVideo 
+                   WITH FORMAT VIDEO;"""
         execute_query_fetch_all(query)
 
         metadata = CatalogManager().get_dataset_metadata("", "MyVideo")
@@ -45,3 +50,40 @@ class LoadExecutorTest(unittest.TestCase):
         actual_batch.sort()
         expected_batch = list(create_dummy_batches())
         self.assertEqual([actual_batch], expected_batch)
+
+    # integration test for csv
+    def test_should_load_csv_in_table(self):
+        
+        # loading a csv requires a table to be created first
+        create_table_query = """ 
+
+            CREATE TABLE IF NOT EXISTS MyVideoCSV (
+                id INTEGER UNIQUE,
+                frame_id INTEGER,
+                video_id INTEGER,
+                dataset_name TEXT(30),
+                label TEXT(30),
+                bbox NDARRAY FLOAT32(4),
+                object_id INTEGER
+            );
+            
+            """
+        execute_query_fetch_all(create_table_query)
+
+        # load the CSV
+        load_query = """LOAD DATA INFILE 'dummy.csv' INTO MyVideoCSV
+                   WITH FORMAT CSV;"""
+        execute_query_fetch_all(load_query)
+
+        # execute a select query
+        select_query = """SELECT id, frame_id, video_id,
+                          dataset_name, label, bbox, 
+                          object_id
+                          FROM MyVideoCSV;"""
+
+        actual_batch = execute_query_fetch_all(select_query)
+        actual_batch.sort()
+        
+        # assert the batches are equal
+        expected_batch = create_dummy_csv_batches()
+        self.assertEqual(actual_batch, expected_batch)

--- a/test/optimizer/test_statement_to_opr_convertor.py
+++ b/test/optimizer/test_statement_to_opr_convertor.py
@@ -37,7 +37,7 @@ from eva.expression.constant_value_expression import ConstantValueExpression
 from eva.expression.comparison_expression import ComparisonExpression
 from eva.expression.abstract_expression import ExpressionType
 
-from eva.parser.types import ParserOrderBySortType
+from eva.parser.types import ParserOrderBySortType, FileFormatType
 
 
 class StatementToOprTest(unittest.TestCase):
@@ -206,10 +206,17 @@ statement_to_opr_convertor.column_definition_to_udf_io')
             self, mock_create, mock_bind, mock_load):
         mock_bind.return_value = MagicMock()
         table_ref = TableRef(TableInfo("test"))
-        stmt = MagicMock(table=table_ref, path='path')
+        column_list = []
+        file_format = FileFormatType.VIDEO
+        file_options = {}
+        file_options['file_format'] = file_format
+        stmt = MagicMock(table=table_ref, path='path', 
+                         column_list=column_list, 
+                         file_options=file_options)
         StatementToPlanConvertor().visit_load_data(stmt)
         mock_bind.assert_called_once_with(table_ref.table)
-        mock_load.assert_called_once_with(mock_bind.return_value, 'path')
+        mock_load.assert_called_once_with(mock_bind.return_value, 'path',
+                                          column_list, file_options)
         mock_create.assert_not_called()
 
     @patch('eva.optimizer.statement_to_opr_convertor.LogicalLoadData')
@@ -219,12 +226,19 @@ statement_to_opr_convertor.column_definition_to_udf_io')
             self, mock_create, mock_bind, mock_load):
         mock_bind.return_value = None
         table_ref = TableRef(TableInfo("test"))
-        stmt = MagicMock(table=table_ref, path='path')
+        column_list = []
+        file_format = FileFormatType.VIDEO
+        file_options = {}
+        file_options['file_format'] = file_format
+        stmt = MagicMock(table=table_ref, path='path',
+                         column_list=column_list, 
+                         file_options=file_options)
         StatementToPlanConvertor().visit_load_data(stmt)
         mock_create.assert_called_once_with(table_ref.table.table_name)
         mock_bind.assert_called_with(table_ref.table)
-        mock_load.assert_called_with(mock_create.return_value, 'path')
-
+        mock_load.assert_called_with(mock_create.return_value, 'path',
+                                     column_list, file_options)
+    
     @patch('eva.optimizer.statement_to_opr_convertor.bind_dataset')
     @patch('eva.optimizer.statement_to_opr_convertor.bind_columns_expr')
     @patch('eva.optimizer.statement_to_opr_convertor.bind_predicate_expr')
@@ -439,7 +453,8 @@ statement_to_opr_convertor.column_definition_to_udf_io')
                 MagicMock()], [
                 MagicMock()])
         query_derived_plan = LogicalQueryDerivedGet()
-        load_plan = LogicalLoadData(MagicMock(), MagicMock())
+        load_plan = LogicalLoadData(MagicMock(), MagicMock(), 
+                                    MagicMock(), MagicMock())
         self.assertEqual(create_plan, create_plan)
         self.assertEqual(create_udf_plan, create_udf_plan)
         self.assertNotEqual(create_plan, create_udf_plan)

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -32,7 +32,7 @@ from eva.expression.tuple_value_expression import TupleValueExpression
 from eva.expression.constant_value_expression import ConstantValueExpression
 
 from eva.parser.table_ref import TableRef, TableInfo
-from eva.parser.types import ParserOrderBySortType
+from eva.parser.types import ParserOrderBySortType, FileFormatType
 from eva.catalog.column_type import ColumnType, NdArrayType
 
 from pathlib import Path
@@ -358,13 +358,46 @@ class ParserTests(unittest.TestCase):
 
         self.assertEqual(create_udf_stmt, expected_stmt)
 
-    def test_load_data_statement(self):
+    def test_load_video_data_statement(self):
         parser = Parser()
-        load_data_query = """LOAD DATA INFILE 'data/video.mp4' INTO MyVideo;"""
+        load_data_query = """LOAD DATA INFILE 'data/video.mp4'
+                             INTO MyVideo WITH FORMAT VIDEO;"""
+        file_options = {}
+        file_options['file_format'] = FileFormatType.VIDEO
+        column_list = None
         expected_stmt = LoadDataStatement(
             TableRef(
                 TableInfo('MyVideo')),
-            Path('data/video.mp4'))
+            Path('data/video.mp4'),
+            column_list,
+            file_options)
+        eva_statement_list = parser.parse(load_data_query)
+        self.assertIsInstance(eva_statement_list, list)
+        self.assertEqual(len(eva_statement_list), 1)
+        self.assertEqual(
+            eva_statement_list[0].stmt_type,
+            StatementType.LOAD_DATA)
+
+        load_data_stmt = eva_statement_list[0]
+        self.assertEqual(load_data_stmt, expected_stmt)
+
+    def test_load_csv_data_statement(self):
+        parser = Parser()
+        load_data_query = """LOAD DATA INFILE 'data/meta.csv'
+                             INTO 
+                             MyMeta (id, frame_id, video_id, label)
+                             WITH FORMAT CSV;"""
+        file_options = {}
+        file_options['file_format'] = FileFormatType.CSV
+        expected_stmt = LoadDataStatement(
+            TableRef(
+                TableInfo('MyMeta')),
+            Path('data/meta.csv'), [
+                TupleValueExpression('id'),
+                TupleValueExpression('frame_id'),
+                TupleValueExpression('video_id'),
+                TupleValueExpression('label')],
+            file_options)
         eva_statement_list = parser.parse(load_data_query)
         self.assertIsInstance(eva_statement_list, list)
         self.assertEqual(len(eva_statement_list), 1)
@@ -421,7 +454,9 @@ class ParserTests(unittest.TestCase):
 
     def test_should_return_false_for_unequal_expression(self):
         table = TableRef(TableInfo('MyVideo'))
-        load_stmt = LoadDataStatement(table, Path('data/video.mp4'))
+        load_stmt = LoadDataStatement(
+            table, Path('data/video.mp4'), 
+            FileFormatType.VIDEO)
         insert_stmt = InsertTableStatement(table)
         create_udf = CreateUDFStatement(
             'udf', False, [

--- a/test/parser/test_parser_visitor.py
+++ b/test/parser/test_parser_visitor.py
@@ -26,6 +26,7 @@ from eva.parser.evaql.evaql_parser import evaql_parser
 from eva.expression.abstract_expression import ExpressionType
 from eva.expression.function_expression import ExecutionMode
 from eva.parser.table_ref import TableRef
+from eva.parser.types import FileFormatType
 from antlr4 import TerminalNode
 
 
@@ -348,8 +349,14 @@ class ParserVisitorTests(unittest.TestCase):
         table = 'myVideo'
         path = MagicMock()
         path.value = 'video.mp4'
+        column_list = None
+        file_format = FileFormatType.VIDEO
+        file_options = {}
+        file_options['file_format'] = file_format
         params = {ctx.fileName.return_value: path,
-                  ctx.tableName.return_value: table}
+                  ctx.tableName.return_value: table,
+                  ctx.fileOptions.return_value: file_options,
+                  ctx.uidList.return_value: column_list}
 
         def side_effect(arg):
             return params[arg]
@@ -357,7 +364,11 @@ class ParserVisitorTests(unittest.TestCase):
         mock_visit.side_effect = side_effect
         visitor = ParserVisitor()
         visitor.visitLoadStatement(ctx)
-        mock_visit.assert_has_calls(
-            [call(ctx.fileName()), call(ctx.tableName())])
+        mock_visit.assert_has_calls([call(ctx.fileName()),
+                                     call(ctx.tableName()), 
+                                     call(ctx.fileOptions()),
+                                     call(ctx.uidList())])
         mock_load.assert_called_once()
-        mock_load.assert_called_with(TableRef('myVideo'), 'video.mp4')
+        mock_load.assert_called_with(TableRef('myVideo'), 'video.mp4',
+                                     column_list,
+                                     file_options)

--- a/test/planner/test_plan.py
+++ b/test/planner/test_plan.py
@@ -25,6 +25,7 @@ from eva.planner.load_data_plan import LoadDataPlan
 from eva.planner.upload_plan import UploadPlan
 from eva.planner.union_plan import UnionPlan
 from eva.planner.types import PlanOprType
+from eva.parser.types import FileFormatType
 
 
 class PlanNodeTests(unittest.TestCase):
@@ -80,16 +81,30 @@ class PlanNodeTests(unittest.TestCase):
     def test_load_data_plan(self):
         table_metainfo = 'meta_info'
         file_path = 'test.mp4'
+        file_format = FileFormatType.VIDEO
+        file_options = {}
+        file_options['file_format'] = file_format
+        column_list = None
         batch_mem_size = 3000
         plan_str = 'LoadDataPlan(table_id={}, file_path={}, \
-            batch_mem_size={})'.format(table_metainfo,
-                                       file_path,
-                                       batch_mem_size)
-        plan = LoadDataPlan(table_metainfo, file_path, batch_mem_size)
+            batch_mem_size={}, \
+            column_list={}, \
+            file_options={})'.format(table_metainfo,
+                                     file_path,
+                                     batch_mem_size,
+                                     column_list,
+                                     file_options)
+        plan = LoadDataPlan(table_metainfo, file_path,
+                            batch_mem_size, column_list,
+                            file_options)
         self.assertEqual(plan.opr_type, PlanOprType.LOAD_DATA)
         self.assertEqual(plan.table_metainfo, table_metainfo)
         self.assertEqual(plan.file_path, file_path)
         self.assertEqual(plan.batch_mem_size, batch_mem_size)
+
+        print(f"plan: {str(plan)}")
+        print(f"plan_str: {plan_str}")
+
         self.assertEqual(str(plan), plan_str)
 
     def test_upload_plan(self):

--- a/test/readers/test_csv_reader.py
+++ b/test/readers/test_csv_reader.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+# Copyright 2018-2020 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import unittest
+
+from eva.readers.csv_reader import CSVReader
+
+from test.util import create_sample_csv 
+from test.util import file_remove
+from test.util import NUM_FRAMES, PATH_PREFIX, FRAME_SIZE
+from test.util import create_dummy_csv_batches
+from eva.expression.tuple_value_expression import TupleValueExpression
+
+
+class CSVLoaderTest(unittest.TestCase):
+
+    def setUp(self):
+        create_sample_csv()
+
+    def tearDown(self):
+        file_remove('dummy.csv')
+        
+    def test_should_return_one_batch(self):
+
+        column_list = [
+            TupleValueExpression(col_name='id', table_name='dummy'),
+            TupleValueExpression(col_name='frame_id', table_name='dummy'),
+            TupleValueExpression(col_name='video_id', table_name='dummy')
+        ]
+        
+        # call the CSVReader
+        csv_loader = CSVReader(
+            file_url=os.path.join(PATH_PREFIX, 'dummy.csv'),
+            column_list=column_list,
+            batch_mem_size=NUM_FRAMES * FRAME_SIZE)
+
+        # get the batches
+        batches = list(csv_loader.read())
+        expected = list(create_dummy_csv_batches())
+
+        # assert batches are equal
+        self.assertTrue(batches, expected)

--- a/test/util.py
+++ b/test/util.py
@@ -62,6 +62,47 @@ def custom_list_of_dicts_equal(one, two):
     return True
 
 
+def convert_bbox(bbox):
+    return np.array([np.float32(coord) for coord in bbox.split(",")])
+
+
+def create_sample_csv(num_frames=NUM_FRAMES):
+    try:
+        os.remove(os.path.join(PATH_PREFIX, 'dummy.csv'))
+    except FileNotFoundError:
+        pass
+    
+    sample_meta = {}
+
+    index = 0
+    sample_labels = ['car', 'pedestrian', 'bicycle']
+    num_videos = 2
+    for video_id in range(num_videos):
+        for frame_id in range(num_frames):
+            random_coords = 200 + 300 * np.random.random(4)
+            sample_meta[index] = {
+                'id': index,
+                'frame_id': frame_id,
+                'video_id': video_id, 
+                'dataset_name': 'test_dataset',
+                'label': sample_labels[np.random.choice(len(sample_labels))],
+                'bbox': ",".join([str(coord) for coord in random_coords]),
+                'object_id': np.random.choice(3)
+            }
+            
+            index += 1
+            
+    df_sample_meta = pd.DataFrame.from_dict(sample_meta, "index")
+    df_sample_meta.to_csv(os.path.join(PATH_PREFIX, 'dummy.csv'), 
+                          index=False)
+
+
+def create_dummy_csv_batches():
+    df = pd.read_csv(os.path.join(PATH_PREFIX, 'dummy.csv'), 
+                     converters={'bbox': convert_bbox})
+    return Batch(df)
+
+
 def create_sample_video(num_frames=NUM_FRAMES):
     try:
         os.remove(os.path.join(PATH_PREFIX, 'dummy.avi'))


### PR DESCRIPTION
Major changes:

1. Support to load CSVs into tables. Split load_executors as load_video_executors and load_csv_executors
2. Added support to specify FORMAT in query
3. Added support to specify columns in LOAD query. 
4. Added/modified all the relevant testcases for this. 
5. Added helper scripts to load datasets.

We can now execute queries like:

`LOAD DATA INFILE 'data/meta.csv' INTO  MyMeta (id, frame_id, video_id, label) WITH FORMAT CSV;`