### PR TITLE
Fix EVA Configuration

### DIFF
--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -27,37 +27,38 @@ from eva.configuration.dictionary import (
     EVA_DATASET_DIR,
     EVA_DEFAULT_DIR,
     EVA_INSTALLATION_DIR,
+    EVA_UPLOAD_DIR,
 )
 
 
-def get_base_config():
-    ymlpath = None
+def get_base_config() -> Path:
     if importlib_resources.is_resource("eva", EVA_CONFIG_FILE):
-        with importlib_resources.path("eva", EVA_CONFIG_FILE) as path:
-            ymlpath = path
-    else:  # For local dev environments without package installed
-        ymlpath = os.path.join(EVA_INSTALLATION_DIR, EVA_CONFIG_FILE)
-    return ymlpath
+        with importlib_resources.path("eva", EVA_CONFIG_FILE) as yml_path:
+            return yml_path
+    else:
+        # For local dev environments without package installed
+        return EVA_INSTALLATION_DIR / EVA_CONFIG_FILE
 
 
 def bootstrap_environment():
     # create eva directory in user home
-    eva_home_directory = Path(EVA_DEFAULT_DIR)
-    eva_home_directory.mkdir(parents=True, exist_ok=True)
+    EVA_DEFAULT_DIR.mkdir(parents=True, exist_ok=True)
 
     # copy default config to eva directory
-    config_path = eva_home_directory / EVA_CONFIG_FILE
+    config_path = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
     if not config_path.exists():
-        default_config_path = get_base_config()
-        shutil.copy(str(default_config_path), str(config_path))
+        default_config_path = get_base_config().resolve()
+        shutil.copy(
+            str(default_config_path.resolve()), str(config_path.parent.resolve())
+        )
 
     # copy udfs to eva directory
-    udfs_path = Path(EVA_DEFAULT_DIR + "/udfs/")
+    udfs_path = EVA_DEFAULT_DIR / "udfs"
     if not udfs_path.exists():
-        default_udfs_path = EVA_INSTALLATION_DIR + "/udfs/"
-        shutil.copytree(default_udfs_path, str(udfs_path))
+        default_udfs_path = EVA_INSTALLATION_DIR / "udfs"
+        shutil.copytree(str(default_udfs_path.resolve()), str(udfs_path.resolve()))
 
-    with open(config_path, "r") as ymlfile:
+    with config_path.open("r") as ymlfile:
         cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
 
     # fill default values for dataset, database and upload loc if not present
@@ -67,20 +68,22 @@ def bootstrap_environment():
 
     if not dataset_location or not database_uri or not upload_location:
         if not dataset_location:
-            dataset_location = str(eva_home_directory / EVA_DATASET_DIR)
-            update_value_config(cfg, "core", "datasets_dir", dataset_location)
+            dataset_location = EVA_DEFAULT_DIR / EVA_DATASET_DIR
+            update_value_config(
+                cfg, "core", "datasets_dir", str(dataset_location.resolve())
+            )
         if not database_uri:
             database_uri = DB_DEFAULT_URI
             update_value_config(cfg, "core", "catalog_database_uri", database_uri)
 
-        # Ref: https://stackoverflow.com/a/847866
-        upload_location = str(eva_home_directory / tempfile.gettempdir())
-        update_value_config(cfg, "storage", "upload_dir", upload_location)
+        upload_location = EVA_DEFAULT_DIR / EVA_UPLOAD_DIR
+        update_value_config(
+            cfg, "storage", "upload_dir", str(upload_location.resolve())
+        )
 
         # Create upload directory in eva home directory if it does not exist
-        upload_location = Path(upload_location)
         upload_location.mkdir(parents=True, exist_ok=True)
 
         # update config on disk
-        with open(config_path, "w") as ymlfile:
+        with config_path.open("w") as ymlfile:
             ymlfile.write(yaml.dump(cfg))

--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib.resources as importlib_resources
-import os
 import shutil
-import tempfile
 from pathlib import Path
 
 import yaml

--- a/eva/configuration/configuration_manager.py
+++ b/eva/configuration/configuration_manager.py
@@ -29,8 +29,8 @@ class ConfigurationManager(object):
 
             bootstrap_environment()  # Setup eva in home directory
 
-            ymlpath = EVA_DEFAULT_DIR + EVA_CONFIG_FILE
-            with open(ymlpath, "r") as ymlfile:
+            ymlpath = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
+            with ymlpath.open("r") as ymlfile:
                 cls._cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
 
         return cls._instance

--- a/eva/configuration/dictionary.py
+++ b/eva/configuration/dictionary.py
@@ -17,11 +17,11 @@ from pathlib import Path
 
 import eva
 
-EVA_INSTALLATION_DIR = os.path.dirname(eva.__file__)
-EVA_DEFAULT_DIR = str(Path.home()) + "/.eva/"
+EVA_INSTALLATION_DIR = Path(eva.__file__).parent
+EVA_DEFAULT_DIR = Path.home() / ".eva"
 EVA_DATASET_DIR = "eva_datasets"
 EVA_UPLOAD_DIR = "tmp"
 EVA_CONFIG_FILE = "eva.yml"
 CATALOG_DIR = "catalog"
 DATASET_DATAFRAME_NAME = "dataset"
-DB_DEFAULT_URI = "sqlite:///{}eva_catalog.db".format(EVA_DEFAULT_DIR)
+DB_DEFAULT_URI = "sqlite:///{}/eva_catalog.db".format(EVA_DEFAULT_DIR.resolve())

--- a/eva/configuration/dictionary.py
+++ b/eva/configuration/dictionary.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from pathlib import Path
 
 import eva

--- a/script/test/cleanup.sh
+++ b/script/test/cleanup.sh
@@ -4,7 +4,7 @@ USER=${1:-root}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rm -rf $DIR/../../eva_datasets
-rm -rf $HOME/tmp
+rm -rf $HOME/.eva/tmp
 
 mysql -u $USER -e 'Drop DATABASE eva_catalog;'
 mysql -u $USER -e 'CREATE DATABASE IF NOT EXISTS eva_catalog;'

--- a/script/test/cleanup.sh
+++ b/script/test/cleanup.sh
@@ -4,6 +4,7 @@ USER=${1:-root}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 rm -rf $DIR/../../eva_datasets
+rm -rf $HOME/tmp
 
 mysql -u $USER -e 'Drop DATABASE eva_catalog;'
 mysql -u $USER -e 'CREATE DATABASE IF NOT EXISTS eva_catalog;'


### PR DESCRIPTION
I was getting periodic nondeterministic test failures due to how broken the paths are on system setup.

Use pathlib library for calculating paths when starting eva_server

Building paths by appending strings is error-prone and will not work on other platforms. Python pathlib takes
care of that automatically.

Remove Python reference to python `gettempdir()` in bootstrap_environment

On ada-01, I do not have permission to access `/tmp`, so no matter what I do, the unit tests will fail periodically and need to be fixed. Since eva already creates a `~/.eva/` directory we can use `/.eva/tmp` as a temporary directory and clean it up in the cleanup script.

`EVA_UPLOAD_DIR` in `dictionary.py` was also unused previously which caused confusion.

