### PR TITLE
stoping auto execution of jupyter notebooks

### DIFF
--- a/api-docs/conf.py
+++ b/api-docs/conf.py
@@ -105,6 +105,7 @@ for i in os.listdir('../tutorials'):
     if i.endswith('.ipynb'):
         shutil.copy(f'../tutorials/{i}', './source/tutorials/')
 
+jupyter_execute_notebooks = "off"
 
 # -- Initialize Sphinx ----------------------------------------------
 def setup(sphinx):


### PR DESCRIPTION
changing `myst-nb` default behaviour of running notebooks before rendering.