### PR TITLE
bugfix: Make ConfigurationManager read and update operate on eva.yml

### DIFF
--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -99,22 +99,18 @@ def bootstrap_environment(eva_config_dir: Path, eva_installation_dir: Path):
     ):
         if not install_dir:
             update_value_config(
-                cfg, "core", "eva_installation_dir", str(default_install_dir.resolve())
+                config_file_path, "core", "eva_installation_dir", str(default_install_dir.resolve())
             )
         if not dataset_location:
             dataset_location = EVA_DEFAULT_DIR / EVA_DATASET_DIR
             update_value_config(
-                cfg, "core", "datasets_dir", str(dataset_location.resolve())
+                config_file_path, "core", "datasets_dir", str(dataset_location.resolve())
             )
         if not database_uri:
             database_uri = DB_DEFAULT_URI
-            update_value_config(cfg, "core", "catalog_database_uri", database_uri)
+            update_value_config(config_file_path, "core", "catalog_database_uri", database_uri)
 
         upload_dir = eva_config_dir / EVA_UPLOAD_DIR
-        update_value_config(cfg, "storage", "upload_dir", str(upload_dir.resolve()))
+        update_value_config(config_file_path, "storage", "upload_dir", str(upload_dir.resolve()))
         # Create upload directory in eva home directory if it does not exist
         upload_dir.mkdir(parents=True, exist_ok=True)
-
-        # update config on disk
-        with config_file_path.open("w") as ymlfile:
-            ymlfile.write(yaml.dump(cfg))

--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -77,22 +77,18 @@ def bootstrap_environment(eva_config_dir: Path, eva_installation_dir: Path):
         raise OSError(f"Eva configuration file not found at {ymlfile}")
 
     # set logging level
-    mode = read_value_config(cfg, "core", "mode")
+    mode = read_value_config(config_file_path, "core", "mode")
     assert mode == "debug" or mode == "release"
-    level = None
-    if mode == "debug":
-        level = DEBUG
-    else:
-        level = WARN
+    level = WARN if mode == "release" else DEBUG
 
     logger.setLevel(level)
     logger.debug("Setting logging level to: " + str(level))
 
     # fill default values for eva installation dir,
     # dataset, database and upload loc if not present
-    install_dir = read_value_config(cfg, "core", "eva_installation_dir")
-    dataset_location = read_value_config(cfg, "core", "datasets_dir")
-    database_uri = read_value_config(cfg, "core", "catalog_database_uri")
+    install_dir = read_value_config(config_file_path, "core", "eva_installation_dir")
+    dataset_location = read_value_config(config_file_path, "core", "datasets_dir")
+    database_uri = read_value_config(config_file_path, "core", "catalog_database_uri")
     upload_location = None
 
     if (

--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -17,8 +17,6 @@ import shutil
 from logging import DEBUG, WARN
 from pathlib import Path
 
-import yaml
-
 from eva.configuration.config_utils import read_value_config, update_value_config
 from eva.configuration.constants import (
     DB_DEFAULT_URI,
@@ -70,12 +68,6 @@ def bootstrap_environment(eva_config_dir: Path, eva_installation_dir: Path):
         default_udfs_path = default_install_dir / "udfs"
         shutil.copytree(str(default_udfs_path.resolve()), str(udfs_path.resolve()))
 
-    with config_file_path.open("r") as ymlfile:
-        cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
-
-    if cfg is None:
-        raise OSError(f"Eva configuration file not found at {ymlfile}")
-
     # set logging level
     mode = read_value_config(config_file_path, "core", "mode")
     assert mode == "debug" or mode == "release"
@@ -99,18 +91,28 @@ def bootstrap_environment(eva_config_dir: Path, eva_installation_dir: Path):
     ):
         if not install_dir:
             update_value_config(
-                config_file_path, "core", "eva_installation_dir", str(default_install_dir.resolve())
+                config_file_path,
+                "core",
+                "eva_installation_dir",
+                str(default_install_dir.resolve()),
             )
         if not dataset_location:
             dataset_location = EVA_DEFAULT_DIR / EVA_DATASET_DIR
             update_value_config(
-                config_file_path, "core", "datasets_dir", str(dataset_location.resolve())
+                config_file_path,
+                "core",
+                "datasets_dir",
+                str(dataset_location.resolve()),
             )
         if not database_uri:
             database_uri = DB_DEFAULT_URI
-            update_value_config(config_file_path, "core", "catalog_database_uri", database_uri)
+            update_value_config(
+                config_file_path, "core", "catalog_database_uri", database_uri
+            )
 
         upload_dir = eva_config_dir / EVA_UPLOAD_DIR
-        update_value_config(config_file_path, "storage", "upload_dir", str(upload_dir.resolve()))
+        update_value_config(
+            config_file_path, "storage", "upload_dir", str(upload_dir.resolve())
+        )
         # Create upload directory in eva home directory if it does not exist
         upload_dir.mkdir(parents=True, exist_ok=True)

--- a/eva/configuration/config_utils.py
+++ b/eva/configuration/config_utils.py
@@ -24,7 +24,15 @@ def read_value_config(config_path: Path, category: str, key: str) -> Any:
         return config_obj[category][key]
 
 
-def update_value_config(cfg: Any, category: str, key: str, value: str):
-    category_data = cfg.get(category, None)
-    if category_data:
-        category_data[key] = value
+def update_value_config(config_path: Path, category: str, key: str, value: str):
+    # read config file
+    with config_path.open("r") as yml_file:
+        config_obj = yaml.load(yml_file)
+        if config_obj is None:
+            raise ValueError(f"Invalid path to config file {config_path}")
+
+    # update value and write back to config file
+    config_obj[category][key] = value
+    with config_path.open("w") as yml_file:
+        yml_file.write(yaml.dump(config_obj))
+

--- a/eva/configuration/config_utils.py
+++ b/eva/configuration/config_utils.py
@@ -22,7 +22,7 @@ def read_value_config(config_path: Path, category: str, key: str) -> Any:
     with config_path.open("r") as yml_file:
         config_obj = yaml.load(yml_file, Loader=yaml.FullLoader)
         if config_obj is None:
-            raise ValueError(f"Invalid path to config file {config_path}")
+            raise ValueError(f"Invalid yml file at {config_path}")
         return config_obj[category][key]
 
 
@@ -31,7 +31,7 @@ def update_value_config(config_path: Path, category: str, key: str, value: str):
     with config_path.open("r") as yml_file:
         config_obj = yaml.load(yml_file, Loader=yaml.FullLoader)
         if config_obj is None:
-            raise ValueError(f"Invalid path to config file {config_path}")
+            raise ValueError(f"Invalid yml file at {config_path}")
 
     # update value and write back to config file
     config_obj[category][key] = value

--- a/eva/configuration/config_utils.py
+++ b/eva/configuration/config_utils.py
@@ -12,9 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import yaml
-from typing import Any
 from pathlib import Path
+from typing import Any
+
+import yaml
+
 
 def read_value_config(config_path: Path, category: str, key: str) -> Any:
     with config_path.open("r") as yml_file:
@@ -35,4 +37,3 @@ def update_value_config(config_path: Path, category: str, key: str, value: str):
     config_obj[category][key] = value
     with config_path.open("w") as yml_file:
         yml_file.write(yaml.dump(config_obj))
-

--- a/eva/configuration/config_utils.py
+++ b/eva/configuration/config_utils.py
@@ -12,11 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import yaml
 from typing import Any
+from pathlib import Path
 
-
-def read_value_config(cfg: Any, category: str, key: str) -> Any:
-    return cfg.get(category, {}).get(key)
+def read_value_config(config_path: Path, category: str, key: str) -> Any:
+    with config_path.open("r") as yml_file:
+        config_obj = yaml.load(yml_file)
+        if config_obj is None:
+            raise ValueError(f"Invalid path to config file {config_path}")
+        return config_obj[category][key]
 
 
 def update_value_config(cfg: Any, category: str, key: str, value: str):

--- a/eva/configuration/config_utils.py
+++ b/eva/configuration/config_utils.py
@@ -20,7 +20,7 @@ import yaml
 
 def read_value_config(config_path: Path, category: str, key: str) -> Any:
     with config_path.open("r") as yml_file:
-        config_obj = yaml.load(yml_file)
+        config_obj = yaml.load(yml_file, Loader=yaml.FullLoader)
         if config_obj is None:
             raise ValueError(f"Invalid path to config file {config_path}")
         return config_obj[category][key]
@@ -29,7 +29,7 @@ def read_value_config(config_path: Path, category: str, key: str) -> Any:
 def update_value_config(config_path: Path, category: str, key: str, value: str):
     # read config file
     with config_path.open("r") as yml_file:
-        config_obj = yaml.load(yml_file)
+        config_obj = yaml.load(yml_file, Loader=yaml.FullLoader)
         if config_obj is None:
             raise ValueError(f"Invalid path to config file {config_path}")
 

--- a/eva/configuration/configuration_manager.py
+++ b/eva/configuration/configuration_manager.py
@@ -26,6 +26,7 @@ from eva.configuration.constants import (
 class ConfigurationManager(object):
     _instance = None
     _cfg = None
+    _yml_path = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -36,14 +37,14 @@ class ConfigurationManager(object):
                 eva_installation_dir=EVA_INSTALLATION_DIR,
             )  # Setup eva in home directory
 
-            ymlpath = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
-            with ymlpath.open("r") as ymlfile:
+            cls._yml_path = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
+            with cls._yml_path.open("r") as ymlfile:
                 cls._cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
 
         return cls._instance
 
     def get_value(self, category, key):
-        return read_value_config(self._cfg, category, key)
+        return read_value_config(self._yml_path, category, key)
 
     def update_value(self, category, key, value):
         update_value_config(self._cfg, category, key, value)

--- a/eva/configuration/configuration_manager.py
+++ b/eva/configuration/configuration_manager.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import yaml
 
 from eva.configuration.bootstrap_environment import bootstrap_environment
 from eva.configuration.config_utils import read_value_config, update_value_config
@@ -25,8 +24,7 @@ from eva.configuration.constants import (
 
 class ConfigurationManager(object):
     _instance = None
-    _cfg = None
-    _yml_path = None
+    _yml_path = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
 
     def __new__(cls):
         if cls._instance is None:
@@ -36,10 +34,6 @@ class ConfigurationManager(object):
                 eva_config_dir=EVA_DEFAULT_DIR,
                 eva_installation_dir=EVA_INSTALLATION_DIR,
             )  # Setup eva in home directory
-
-            cls._yml_path = EVA_DEFAULT_DIR / EVA_CONFIG_FILE
-            with cls._yml_path.open("r") as ymlfile:
-                cls._cfg = yaml.load(ymlfile, Loader=yaml.FullLoader)
 
         return cls._instance
 

--- a/eva/configuration/configuration_manager.py
+++ b/eva/configuration/configuration_manager.py
@@ -47,4 +47,4 @@ class ConfigurationManager(object):
         return read_value_config(self._yml_path, category, key)
 
     def update_value(self, category, key, value):
-        update_value_config(self._cfg, category, key, value)
+        update_value_config(self._yml_file, category, key, value)

--- a/test/configuration/test_configuration_manager.py
+++ b/test/configuration/test_configuration_manager.py
@@ -30,10 +30,8 @@ class ConfigurationManagerTests(unittest.TestCase):
 
     def test_configuration_manager_read_invalid_category(self):
         with pytest.raises(KeyError):
-            value = self.config.get_value("invalid", "")
-            self.assertEqual(value, None)
+            _ = self.config.get_value("invalid", "")
 
     def test_configuration_manager_read_invalid_key(self):
         with pytest.raises(KeyError):
-            value = self.config.get_value("core", "invalid")
-            self.assertEqual(value, None)
+            _ = self.config.get_value("core", "invalid")

--- a/test/configuration/test_configuration_manager.py
+++ b/test/configuration/test_configuration_manager.py
@@ -24,7 +24,7 @@ class ConfigurationManagerTests(unittest.TestCase):
         self.config = ConfigurationManager()
         return super().setUp()
 
-    def test_configuration_manager_read_nonexistent_key(self):
+    def test_configuration_manager_read_valid_key(self):
         value = self.config.get_value("core", "datasets_dir")
         self.assertNotEqual(value, None)
 

--- a/test/configuration/test_configuration_manager.py
+++ b/test/configuration/test_configuration_manager.py
@@ -13,23 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+import pytest
 
 from eva.configuration.configuration_manager import ConfigurationManager
 
 
 class ConfigurationManagerTests(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def setUp(self) -> None:
+        self.config = ConfigurationManager()
+        return super().setUp()
 
-    def test_configuration_manager_read(self):
-
-        configuration_manager = ConfigurationManager()
-
-        value = configuration_manager.get_value("core", "datasets_dir")
+    def test_configuration_manager_read_nonexistent_key(self):
+        value = self.config.get_value("core", "datasets_dir")
         self.assertNotEqual(value, None)
 
-        value = configuration_manager.get_value("invalid", "")
-        self.assertEqual(value, None)
+    def test_configuration_manager_read_invalid_category(self):
+        with pytest.raises(KeyError):
+            value = self.config.get_value("invalid", "")
+            self.assertEqual(value, None)
 
-        value = configuration_manager.get_value("core", "invalid")
-        self.assertEqual(value, None)
+    def test_configuration_manager_read_invalid_key(self):
+        with pytest.raises(KeyError):
+            value = self.config.get_value("core", "invalid")
+            self.assertEqual(value, None)

--- a/test/configuration/test_configuration_manager.py
+++ b/test/configuration/test_configuration_manager.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+
 import pytest
 
 from eva.configuration.configuration_manager import ConfigurationManager


### PR DESCRIPTION
`ConfigurationManager` is a singleton that loads the contents of `~/.eva/eva.yml` into memory and uses that to read and write configuration values. The issue with that is if the source file changes, the stale values will continue to be used. This causes confusion if the user wants to change configuration values. When EVA becomes distributed, this system breaks down entirely as different processes will operate with different configuration values.

This PR simply reads directly from `~/.eva/eva.yml` when a read is needed and writes back to the file when `update_value` is called.