### PR TITLE
Fix lateral join with sample

### DIFF
--- a/eva/executor/sample_executor.py
+++ b/eva/executor/sample_executor.py
@@ -40,5 +40,7 @@ class SampleExecutor(AbstractExecutor):
 
         current = 0
         for batch in child_executor.exec():
-            yield batch[current :: self._sample_freq]
+            result_batch = batch[current :: self._sample_freq]
+            result_batch.reset_index()
+            yield result_batch
             current = (current - len(batch)) % self._sample_freq


### PR DESCRIPTION
Reset the index of the data frame after sample.

**Affected query:**
```
SELECT id, label, bbox FROM MyVideo SAMPLE 10 JOIN LATERAL
Unnest(FastRCNNObjectDetector(data)) AS FastRCNN(label, bbox, conf)  WHERE id < 100;
```

**After fix:**
```
Query 1: SELECT id, label, bbox FROM MyVideo SAMPLE 10 JOIN LATERAL
            Unnest(FastRCNNObjectDetector(data)) AS FastRCNN(label, bbox, conf)  WHERE id < 100;
Batch Object:
@dataframe:      myvideo.id FastRCNN.label                                 FastRCNN.bbox
0             0         person     [636.2461, 363.62677, 670.9286, 421.6867]
1             0            car   [795.97406, 198.13599, 905.6496, 239.72403]
2             0            car        [926.5628, 108.79296, 960.0, 130.6397]
3             0            car       [835.3279, 232.23067, 960.0, 291.82022]
4             0            car    [613.3374, 216.78004, 722.1992, 277.64102]
..          ...            ...                                           ...
246          90         person  [706.53204, 139.02707, 723.95685, 168.34686]
247          90            car      [299.8758, 72.73116, 320.4771, 89.23299]
248          90            car    [371.45337, 79.62909, 393.17596, 96.09854]
249          90         person    [840.1208, 290.41873, 887.19464, 342.3853]
250          90            car     [618.98804, 39.95065, 630.6074, 48.40195]

[251 rows x 3 columns]
@batch_size: 251
```