### PR TITLE
fix: petastorm needs pyspark needs openjdk8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 
   }
   stages {
-    stage('Setup and Install Packages') {
+    stage('Setup and Install EVA Packages') {
       parallel {
         stage('Setup Virtual Environment') {
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 
   }
   stages {
-    stage('Setup and Install EVA Packages') {
+    stage('Setup and Install Packages') {
       parallel {
         stage('Setup Virtual Environment') {
           steps {

--- a/docker/eva_jenkins.Dockerfile
+++ b/docker/eva_jenkins.Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get -qq update \
         sudo \
         openjdk-11-jdk \
         openjdk-11-jre \
+        openjdk-8-jdk \
+        openjdk-8-jre \
     && pip install numpy \
     && wget -q https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip -O opencv.zip \
     && unzip -qq opencv.zip -d /opt \


### PR DESCRIPTION
Earlier, installation of jdk8 was upgraded to jdk11. Looks like petastorm tests, which use pyspark has dependencies in openjdk8. Adding installation of openjdk8 in docker setup to run Jenkins tests.