### PR TITLE
fix: coveralls linting failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ minimal_requirement = [
     "pyspark==3.0.2",
     "petastorm==0.11.5",
     "antlr4-python3-runtime==4.10",
-    "pyyaml==5.1"
+    "pyyaml==5.1",
+    "importlib-metadata<5.0",
 ]
 
 formatter_libs = [


### PR DESCRIPTION
Latest release of importlib-metadata (v5.0.0) removes a deprecated endpoint which causes a failure when coveralls tries to lint code.
Ref:
@gaurav274: https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean