### PR TITLE
fix: importing files in /abstract/ dir

### DIFF
--- a/eva/udfs/abstract/__init__.py
+++ b/eva/udfs/abstract/__init__.py
@@ -1,0 +1,15 @@
+# coding=utf-8
+# Copyright 2018-2022 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""abstract user defined functions"""


### PR DESCRIPTION
eva_server doesn't run because some modules (particularly "fastrcnn_object_detector.py") import files in the "eva/udfs/abstract/" dir.
"__init__.py" file (in the "eva/udfs/abstract/" directory - where this file resides) is required for python to treat this directory as a package