### PR TITLE
Fix variable undefined issue in docs

### DIFF
--- a/api-docs/source/overview/installation.rst
+++ b/api-docs/source/overview/installation.rst
@@ -37,6 +37,7 @@ To connect to the EVA server in the notebook, use the following Python code:
     # allow nested asyncio calls for client to connect with server
     import nest_asyncio
     nest_asyncio.apply()
+    from eva.server.db_api import connect
 
     # hostname and port of the server where EVA is running
     connection = connect(host = '0.0.0.0', port = 5432)


### PR DESCRIPTION
Added import statement for defininf `connect` in the [docs](https://evadb.readthedocs.io/en/latest/source/overview/installation.html#connect-to-the-eva-server)

Fixes #515 