### PR TITLE
feat: Support timestamps and querying for timestamps

### DIFF
--- a/eva/binder/binder_utils.py
+++ b/eva/binder/binder_utils.py
@@ -54,6 +54,7 @@ def create_video_metadata(name: str) -> DataFrameMetadata:
         ColumnDefinition(
             "data", ColumnType.NDARRAY, NdArrayType.UINT8, [None, None, None]
         ),
+        ColumnDefinition("timestamp", ColumnType.TEXT, None, []),
     ]
     col_metadata = create_column_metadata(columns)
     uri = str(generate_file_path(name))

--- a/eva/binder/binder_utils.py
+++ b/eva/binder/binder_utils.py
@@ -54,7 +54,7 @@ def create_video_metadata(name: str) -> DataFrameMetadata:
         ColumnDefinition(
             "data", ColumnType.NDARRAY, NdArrayType.UINT8, [None, None, None]
         ),
-        ColumnDefinition("timestamp", ColumnType.TEXT, None, []),
+        ColumnDefinition("seconds", ColumnType.INTEGER, None, []),
     ]
     col_metadata = create_column_metadata(columns)
     uri = str(generate_file_path(name))

--- a/eva/models/storage/batch.py
+++ b/eva/models/storage/batch.py
@@ -31,7 +31,7 @@ class BatchEncoder(json.JSONEncoder):
 
 def as_batch(d):
     if "__dataframe__" in d:
-        return pd.read_json(d["__dataframe__"])
+        return pd.read_json(d["__dataframe__"], convert_dates=False)
     else:
         return d
 

--- a/eva/readers/opencv_reader.py
+++ b/eva/readers/opencv_reader.py
@@ -60,7 +60,7 @@ class OpenCVReader(AbstractReader):
                 _, frame = video.read()
                 frame_id = begin
                 while frame is not None and frame_id <= end:
-                    yield {"id": frame_id, "data": frame, "timestamp": frame_id_to_time_string(frame_id, video.get(cv2.CAP_PROP_FPS))}
+                    yield {"id": frame_id, "data": frame, "seconds": frame_id // video.get(cv2.CAP_PROP_FPS)}
                     _, frame = video.read()
                     frame_id += 1
         else:
@@ -77,6 +77,4 @@ class OpenCVReader(AbstractReader):
                     else:
                         break
 
-def frame_id_to_time_string(frame_id, fps):
-    return str(datetime.timedelta(seconds=(frame_id // fps)))
 

--- a/eva/readers/opencv_reader.py
+++ b/eva/readers/opencv_reader.py
@@ -60,7 +60,7 @@ class OpenCVReader(AbstractReader):
                 _, frame = video.read()
                 frame_id = begin
                 while frame is not None and frame_id <= end:
-                    yield {"id": frame_id, "data": frame, "timestamp": str(datetime.timedelta(seconds=(frame_id // video.get(cv2.CAP_PROP_FPS))))}
+                    yield {"id": frame_id, "data": frame, "timestamp": frame_id_to_time_string(frame_id, video.get(cv2.CAP_PROP_FPS))}
                     _, frame = video.read()
                     frame_id += 1
         else:
@@ -76,3 +76,7 @@ class OpenCVReader(AbstractReader):
                         yield {"id": frame_id, "data": frame}
                     else:
                         break
+
+def frame_id_to_time_string(frame_id, fps):
+    return str(datetime.timedelta(seconds=(frame_id // fps)))
+

--- a/eva/readers/opencv_reader.py
+++ b/eva/readers/opencv_reader.py
@@ -15,6 +15,7 @@
 from typing import Dict, Iterator
 
 import cv2
+import datetime
 
 from eva.expression.abstract_expression import AbstractExpression
 from eva.expression.expression_utils import extract_range_list_from_predicate
@@ -59,7 +60,7 @@ class OpenCVReader(AbstractReader):
                 _, frame = video.read()
                 frame_id = begin
                 while frame is not None and frame_id <= end:
-                    yield {"id": frame_id, "data": frame}
+                    yield {"id": frame_id, "data": frame, "timestamp": str(datetime.timedelta(seconds=(frame_id // video.get(cv2.CAP_PROP_FPS))))}
                     _, frame = video.read()
                     frame_id += 1
         else:

--- a/eva/udfs/timestamp.py
+++ b/eva/udfs/timestamp.py
@@ -1,0 +1,40 @@
+import datetime
+import numpy as np
+import pandas as pd
+import time
+
+from eva.udfs.abstract_udf import AbstractUDF
+
+
+class Timestamp(AbstractUDF):
+    @property
+    def name(self) -> str:
+        return "Timestamp"
+
+    def setup(self):
+        pass
+
+    def forward(self, inp: pd.DataFrame) -> pd.DataFrame:
+        """
+        inp: DataFrame
+            col1        
+        0   int    
+        1   int    
+        out: DataFrame
+            timestamp
+        0   string
+        1   string
+        """
+        # sanity check
+        if len(inp.columns) != 1:
+            raise ValueError("input contains wrong number of columns")
+
+        seconds = pd.DataFrame(inp[inp.columns[0]])
+        timestamp_result = seconds.apply(
+            lambda x: self.format_timestamp(x[0]), axis=1
+        )
+        return pd.DataFrame({"timestamp": timestamp_result.values})
+
+    def format_timestamp(self, num_of_seconds):
+        timestamp = time.strftime('%H:%M:%S', time.gmtime(num_of_seconds))
+        return timestamp

--- a/eva/udfs/udf_bootstrap_queries.py
+++ b/eva/udfs/udf_bootstrap_queries.py
@@ -77,6 +77,14 @@ Fastrcnn_udf_query = """CREATE UDF IF NOT EXISTS FastRCNNObjectDetector
     EVA_INSTALLATION_DIR
 )
 
+Timestamp_udf_query ="""CREATE UDF
+            IF NOT EXISTS  Timestamp
+            INPUT (seconds INTEGER)
+            OUTPUT (timestamp NDARRAY STR(8))
+            TYPE NdarrayUDF
+            IMPL "eva/udfs/timestamp.py";
+        """
+
 
 def init_builtin_udfs(mode="debug"):
     """
@@ -86,7 +94,7 @@ def init_builtin_udfs(mode="debug"):
     Arguments:
         mode (str): 'debug' or 'release'
     """
-    queries = [Fastrcnn_udf_query, ArrayCount_udf_query, Crop_udf_query]
+    queries = [Fastrcnn_udf_query, ArrayCount_udf_query, Crop_udf_query, Timestamp_udf_query]
     queries.extend([DummyObjectDetector_udf_query, DummyMultiObjectDetector_udf_query])
 
     for query in queries:


### PR DESCRIPTION
Timestamp Integration (Group 4 Fall 2022)

Originally we had stored the column as a string, however in eva/binder/binder_utils.py, we changed the column definition to hold integers of strings and created a UDF for formatting the timestamp.

1. Include a new column for timestamps in seconds
2. Ways to create UDF to use function to view formatted timestamp

Run following command:
```
CREATE UDF IF NOT EXISTS Timestamp
INPUT (seconds INTEGER)
OUTPUT (timestamp NDARRAY STR(8))
TYPE NdarrayUDF
IMPL "eva/udfs/timestamp.py";
```

To test this function, please follow these steps:

1. LOAD FILE "./data/mnist/mnist.mp4" INTO MNISTVid;
2. SELECT id, Timestamp(seconds) FROM MNISTVid WHERE Timestamp(seconds)="0:00:10"; (Find all frames associated with a certain second)
3. SELECT id, Timestamp(seconds) FROM MNISTVid WHERE Timestamp(seconds)<"0:00:20"; (Get all frames before 20 seconds)