### PR TITLE
fix: server relaunch does not load metadata tables

### DIFF
--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -459,7 +459,9 @@ class CatalogManager(object):
         self, input_table: DataFrameMetadata
     ) -> DataFrameMetadata:
         """Create a media metainfo table.
-         This table is used to store all media filenames and related information. In order to prevent direct access or modification by users, it should be designated as a SYSTEM_STRUCTURED_DATA type.
+         This table is used to store all media filenames and related information. In
+         order to prevent direct access or modification by users, it should be
+         designated as a SYSTEM_STRUCTURED_DATA type.
         Args:
             input_table (DataFrameMetadata): input video table
 

--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
 from typing import List
 
 from eva.catalog.catalog_type import ColumnType, IndexType, NdArrayType, TableType
@@ -199,6 +200,7 @@ class CatalogManager(object):
         table_info: TableInfo,
         columns: List[ColumnDefinition],
         identifier_column: str = "id",
+        table_type: TableType = TableType.STRUCTURED_DATA,
     ) -> DataFrameMetadata:
         table_name = table_info.table_name
         column_metadata_list = self.create_columns_metadata(columns)
@@ -208,7 +210,7 @@ class CatalogManager(object):
             file_url,
             column_metadata_list,
             identifier_column=identifier_column,
-            table_type=TableType.STRUCTURED_DATA,
+            table_type=table_type,
         )
         return metadata
 
@@ -429,6 +431,9 @@ class CatalogManager(object):
     def get_all_udf_entries(self):
         return self._udf_service.get_all_udfs()
 
+    def get_all_table_entries(self):
+        return self._dataset_service.get_all_datasets()
+
     def get_media_metainfo_table(
         self, input_table: DataFrameMetadata
     ) -> DataFrameMetadata:
@@ -441,7 +446,7 @@ class CatalogManager(object):
             DataFrameMetadata: metainfo table maintained by the system
         """
         # use file_url as the metadata table name
-        media_metadata_name = input_table.file_url
+        media_metadata_name = Path(input_table.file_url).stem
         obj = self.get_dataset_metadata(None, media_metadata_name)
         if not obj:
             err = f"Table with name {media_metadata_name} does not exist in catalog"
@@ -453,9 +458,8 @@ class CatalogManager(object):
     def create_media_metainfo_table(
         self, input_table: DataFrameMetadata
     ) -> DataFrameMetadata:
-        """Get a media metainfo table.
-        Create one if it does not exists
-        We use this table to store all the media filenames and corresponding information
+        """Create a media metainfo table.
+         This table is used to store all media filenames and related information. In order to prevent direct access or modification by users, it should be designated as a SYSTEM_STRUCTURED_DATA type.
         Args:
             input_table (DataFrameMetadata): input video table
 
@@ -463,7 +467,7 @@ class CatalogManager(object):
             DataFrameMetadata: metainfo table maintained by the system
         """
         # use file_url as the metadata table name
-        media_metadata_name = input_table.file_url
+        media_metadata_name = Path(input_table.file_url).stem
         obj = self.get_dataset_metadata(None, media_metadata_name)
         if obj:
             err_msg = f"Table with name {media_metadata_name} already exists"
@@ -472,7 +476,10 @@ class CatalogManager(object):
 
         columns = [ColumnDefinition("file_url", ColumnType.TEXT, None, None)]
         obj = self.create_table_metadata(
-            TableInfo(media_metadata_name), columns, identifier_column=columns[0].name
+            TableInfo(media_metadata_name),
+            columns,
+            identifier_column=columns[0].name,
+            table_type=TableType.SYSTEM_STRUCTURED_DATA,
         )
         return obj
 

--- a/eva/catalog/catalog_type.py
+++ b/eva/catalog/catalog_type.py
@@ -23,6 +23,9 @@ class TableType(IntEnum):
     STRUCTURED_DATA = auto()
     VIDEO_DATA = auto()
     IMAGE_DATA = auto()
+    # reserved for system generated tables
+    # cannot be accessed/modified directly by user
+    SYSTEM_STRUCTURED_DATA = auto()
 
 
 class ColumnType(Enum):

--- a/eva/catalog/services/df_service.py
+++ b/eva/catalog/services/df_service.py
@@ -126,3 +126,9 @@ class DatasetService(BaseService):
             )
             logger.error(err_msg)
             raise RuntimeError(err_msg)
+
+    def get_all_datasets(self):
+        try:
+            return self.model.query.all()
+        except NoResultFound:
+            return []

--- a/eva/executor/plan_executor.py
+++ b/eva/executor/plan_executor.py
@@ -161,5 +161,5 @@ class PlanExecutor:
                 yield from output
             self._clean_execution_tree(execution_tree)
         except Exception as e:
-            logger.error(e)
+            logger.error(str(e))
             raise ExecutorError(e)

--- a/eva/executor/predicate_executor.py
+++ b/eva/executor/predicate_executor.py
@@ -39,7 +39,7 @@ class PredicateExecutor(AbstractExecutor):
                 if not batch.empty():
                     yield batch
         except Exception as e:
-            logger.log(e)
+            logger.error(e)
             raise ExecutorError(e)
 
     def __call__(self, **kwargs) -> Generator[Batch, None, None]:

--- a/eva/executor/seq_scan_executor.py
+++ b/eva/executor/seq_scan_executor.py
@@ -56,7 +56,7 @@ class SequentialScanExecutor(AbstractExecutor):
                 if not batch.empty():
                     yield batch
         except Exception as e:
-            logger.log(e)
+            logger.error(e)
             raise ExecutorError(e)
 
     def __call__(self, **kwargs) -> Generator[Batch, None, None]:

--- a/eva/executor/show_info_executor.py
+++ b/eva/executor/show_info_executor.py
@@ -15,10 +15,13 @@
 import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
+from eva.catalog.catalog_type import TableType
 from eva.executor.abstract_executor import AbstractExecutor
+from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.parser.types import ShowType
 from eva.plan_nodes.show_info_plan import ShowInfoPlan
+from eva.utils.logging_manager import logger
 
 
 class ShowInfoExecutor(AbstractExecutor):
@@ -33,11 +36,25 @@ class ShowInfoExecutor(AbstractExecutor):
 
         Calls the catalog to create udf metadata.
         """
-        catalog_manager = CatalogManager()
-        show_entries = []
-        if self.node.show_type is ShowType.UDFS:
-            udfs = catalog_manager.get_all_udf_entries()
-            for udf in udfs:
-                show_entries.append(udf.display_format())
-
-        yield Batch(pd.DataFrame(show_entries))
+        try:
+            catalog_manager = CatalogManager()
+            show_entries = []
+            if self.node.show_type is ShowType.UDFS:
+                udfs = catalog_manager.get_all_udf_entries()
+                for udf in udfs:
+                    show_entries.append(udf.display_format())
+            elif self.node.show_type is ShowType.TABLES:
+                tables = catalog_manager.get_all_table_entries()
+                for table in tables:
+                    if table.table_type != TableType.SYSTEM_STRUCTURED_DATA:
+                        show_entries.append(table.name)
+                show_entries = {"name": show_entries}
+            else:
+                err_msg = f"Show command does not support type {self.node.show_type}"
+                logger.error(err_msg)
+                raise ExecutorError(err_msg)
+            yield Batch(pd.DataFrame(show_entries))
+        except Exception as e:
+            err_msg = f"Show executor failed with exception {str(e)}"
+            logger.exception(err_msg)
+            raise ExecutorError(err_msg)

--- a/eva/storage/sqlite_storage_engine.py
+++ b/eva/storage/sqlite_storage_engine.py
@@ -192,7 +192,9 @@ class SQLStorageEngine(AbstractStorageEngine):
 
         Argument:
             table: table metadata object of the table
-            where_clause (Dict[str, Any]): where clause use to find the tuples to remove. The key should be the column name and value should be the tuple value. The function assumes an equality condition
+            where_clause (Dict[str, Any]): where clause use to find the tuples to
+            remove. The key should be the column name and value should be the tuple
+            value. The function assumes an equality condition
         """
         try:
             table_to_delete_from = self._try_loading_table_via_reflection(table.name)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ minimal_requirement = [
     "opencv-python>=4.5.4.60,!=4.6.0.66",  # bug in easyocr
     "pandas>=1.1.5",
     "Pillow>=8.4.0",
-    "sqlalchemy==1.3.20",
+    "sqlalchemy>=1.4.0",
     "sqlalchemy-utils>=0.36.6",
     "antlr4-python3-runtime==4.8",
     "lark>=1.0.0",

--- a/test/binder/test_binder_utils.py
+++ b/test/binder/test_binder_utils.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 import unittest
 
-from mock import MagicMock, patch
+from mock import MagicMock, PropertyMock, patch
 
 from eva.binder.binder_utils import BinderError, bind_table_info
+from eva.catalog.catalog_type import TableType
 
 
 class BinderUtilsTest(unittest.TestCase):
@@ -24,12 +25,12 @@ class BinderUtilsTest(unittest.TestCase):
     def test_bind_table_info(self, mock):
         video = MagicMock()
         catalog = mock.return_value
-        catalog.get_dataset_metadata.return_value = "obj"
+        catalog.get_dataset_metadata.return_value = obj = MagicMock()
         bind_table_info(video)
         catalog.get_dataset_metadata.assert_called_with(
             video.database_name, video.table_name
         )
-        self.assertEqual(video.table_obj, "obj")
+        self.assertEqual(video.table_obj, obj)
 
     @patch("eva.binder.binder_utils.CatalogManager")
     def test_bind_table_info_raise(self, mock):
@@ -37,4 +38,16 @@ class BinderUtilsTest(unittest.TestCase):
             video = MagicMock()
             catalog = mock.return_value
             catalog.get_dataset_metadata.return_value = None
+            bind_table_info(video)
+
+    @patch("eva.binder.binder_utils.CatalogManager")
+    def test_bind_table_info_raise_for_system_tables(self, mock):
+        video = MagicMock()
+        catalog = mock.return_value
+        obj = MagicMock()
+        catalog.get_dataset_metadata.return_value = obj
+        type(obj).table_type = PropertyMock(
+            return_value=TableType.SYSTEM_STRUCTURED_DATA
+        )
+        with self.assertRaises(BinderError):
             bind_table_info(video)

--- a/test/integration_tests/test_show_info_executor.py
+++ b/test/integration_tests/test_show_info_executor.py
@@ -17,6 +17,8 @@ import unittest
 import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
+from eva.configuration.constants import EVA_ROOT_DIR
+from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
 from eva.udfs.udf_bootstrap_queries import ArrayCount_udf_query, Fastrcnn_udf_query
 
@@ -24,11 +26,25 @@ NUM_FRAMES = 10
 
 
 class ShowExecutorTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         CatalogManager().reset()
         queries = [Fastrcnn_udf_query, ArrayCount_udf_query]
         for query in queries:
             execute_query_fetch_all(query)
+
+        ua_detrac = f"{EVA_ROOT_DIR}/data/ua_detrac/ua_detrac.mp4"
+        mnist = f"{EVA_ROOT_DIR}/data/mnist/mnist.mp4"
+        actions = f"{EVA_ROOT_DIR}/data/actions/actions.mp4"
+        execute_query_fetch_all(f"LOAD VIDEO '{ua_detrac}' INTO MyVideo;")
+        execute_query_fetch_all(f"LOAD VIDEO '{mnist}' INTO MNIST;")
+        execute_query_fetch_all(f"LOAD VIDEO '{actions}' INTO Actions;")
+
+    @classmethod
+    def tearDownClass(cls):
+        execute_query_fetch_all("DROP TABLE IF EXISTS Actions;")
+        execute_query_fetch_all("DROP TABLE IF EXISTS Mnist;")
+        execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")
 
     # integration test
     def test_show_udfs(self):
@@ -56,3 +72,10 @@ class ShowExecutorTest(unittest.TestCase):
         self.assertTrue(all(expected_df.outputs == result.frames.outputs))
         self.assertTrue(all(expected_df.name == result.frames.name))
         self.assertTrue(all(expected_df.type == result.frames.type))
+
+    def test_show_tables(self):
+        result = execute_query_fetch_all("SHOW TABLES;")
+        self.assertEqual(len(result), 3)
+        expected = {"name": ["MyVideo", "MNIST", "Actions"]}
+        expected_df = pd.DataFrame(expected)
+        self.assertEqual(result, Batch(expected_df))


### PR DESCRIPTION
(1) metadata tables were not being loaded upon server restart, so we implemented reflection to load them; 
(2) the show tables command was not functioning correctly; 
(3) metadata tables have been designated as system tables and can no longer be accessed or modified by user queries.