### PR TITLE
feat: Fix legacy issue in index

### DIFF
--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -97,7 +97,9 @@ class StatementBinder:
 
         # Relax type checking for raw input table.
         if not node.udf_func:
-            assert col.array_type == NdArrayType.FLOAT32, "Index input needs to be float32"
+            assert (
+                col.array_type == NdArrayType.FLOAT32
+            ), "Index input needs to be float32"
 
     @bind.register(SelectStatement)
     def _bind_select_statement(self, node: SelectStatement):

--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -23,7 +23,7 @@ from eva.binder.binder_utils import (
 )
 from eva.binder.statement_binder_context import StatementBinderContext
 from eva.catalog.catalog_manager import CatalogManager
-from eva.catalog.catalog_type import NdArrayType, TableType, IndexType
+from eva.catalog.catalog_type import IndexType, NdArrayType, TableType
 from eva.expression.abstract_expression import AbstractExpression
 from eva.expression.function_expression import FunctionExpression
 from eva.expression.tuple_value_expression import TupleValueExpression
@@ -94,7 +94,9 @@ class StatementBinder:
                 # Feature table type needs to be float32 numpy array.
                 col_def = node.col_list[0]
                 table_ref_obj = node.table_ref.table.table_obj
-                col = [col for col in table_ref_obj.columns if col.name == col_def.name][0]
+                col = [
+                    col for col in table_ref_obj.columns if col.name == col_def.name
+                ][0]
                 if not col.array_type == NdArrayType.FLOAT32:
                     raise BinderError("Index input needs to be float32.")
                 if not len(col.array_dimensions) == 2:
@@ -102,7 +104,9 @@ class StatementBinder:
             else:
                 # Output of the UDF should be 2 dimension and float32 type.
                 catalog_manager = CatalogManager()
-                udf_obj = catalog_manager.get_udf_catalog_entry_by_name(node.udf_func.name)
+                udf_obj = catalog_manager.get_udf_catalog_entry_by_name(
+                    node.udf_func.name
+                )
                 for output in udf_obj.outputs:
                     if not output.array_type == NdArrayType.FLOAT32:
                         raise BinderError("Index input needs to be float32.")

--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -256,9 +256,10 @@ class CatalogManager(object):
         save_file_path: str,
         index_type: IndexType,
         feat_column: ColumnCatalogEntry,
+        udf_signature: str,
     ) -> IndexCatalogEntry:
         index_catalog_entry = self._index_service.insert_entry(
-            name, save_file_path, index_type, feat_column
+            name, save_file_path, index_type, feat_column, udf_signature
         )
         return index_catalog_entry
 

--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -255,11 +255,10 @@ class CatalogManager(object):
         name: str,
         save_file_path: str,
         index_type: IndexType,
-        secondary_index_table: TableCatalogEntry,
         feat_column: ColumnCatalogEntry,
     ) -> IndexCatalogEntry:
         index_catalog_entry = self._index_service.insert_entry(
-            name, save_file_path, index_type, secondary_index_table, feat_column
+            name, save_file_path, index_type, feat_column
         )
         return index_catalog_entry
 

--- a/eva/catalog/catalog_type.py
+++ b/eva/catalog/catalog_type.py
@@ -97,6 +97,4 @@ class IndexType(EVAEnum):
 
     @classmethod
     def is_faiss_index_type(cls, t):
-        return t in [
-            cls.HNSW
-        ]
+        return t in [cls.HNSW]

--- a/eva/catalog/catalog_type.py
+++ b/eva/catalog/catalog_type.py
@@ -94,3 +94,9 @@ class NdArrayType(EVAEnum):
 
 class IndexType(EVAEnum):
     HNSW  # noqa: F821
+
+    @classmethod
+    def is_faiss_index_type(cls, t):
+        return t in [
+            cls.HNSW
+        ]

--- a/eva/catalog/models/index_catalog.py
+++ b/eva/catalog/models/index_catalog.py
@@ -30,6 +30,8 @@ class IndexCatalog(BaseModel):
     `_save_file_path:` the path to the index file on disk
     `_type:` the type of the index (refer to `IndexType`)
     `_feat_column_id:` the `_row_id` of the `ColumnCatalog` entry for the column on which the index is built.
+    `_udf_signature:` if the index is created by running udf expression on input column, this will store
+                      the udf signature of the used udf. Otherwise, this field is None.
     """
 
     __tablename__ = "index_catalog"
@@ -38,6 +40,8 @@ class IndexCatalog(BaseModel):
     _save_file_path = Column("save_file_path", String(128))
     _type = Column("type", Enum(IndexType), default=Enum)
     _feat_column_id = Column("column_id", Integer, ForeignKey("column_catalog._row_id"))
+    _udf_signature = Column("udf", String, default=None)
+
     _feat_column = relationship("ColumnCatalog")
 
     def __init__(
@@ -46,11 +50,13 @@ class IndexCatalog(BaseModel):
         save_file_path: str,
         type: IndexType,
         feat_column_id: int = None,
+        udf_signature: str = None,
     ):
         self._name = name
         self._save_file_path = save_file_path
         self._type = type
         self._feat_column_id = feat_column_id
+        self._udf_signature = udf_signature
 
     def as_dataclass(self) -> "IndexCatalogEntry":
         feat_column = self._feat_column.as_dataclass() if self._feat_column else None
@@ -60,6 +66,7 @@ class IndexCatalog(BaseModel):
             save_file_path=self._save_file_path,
             type=self._type,
             feat_column_id=self._feat_column_id,
+            udf_signature=self._udf_signature,
             feat_column=feat_column,
         )
 
@@ -75,4 +82,5 @@ class IndexCatalogEntry:
     type: IndexType
     row_id: int = None
     feat_column_id: int = None
+    udf_signature: str = None
     feat_column: ColumnCatalogEntry = None

--- a/eva/catalog/models/index_catalog.py
+++ b/eva/catalog/models/index_catalog.py
@@ -21,7 +21,6 @@ from sqlalchemy.types import Enum
 from eva.catalog.catalog_type import IndexType
 from eva.catalog.models.base_model import BaseModel
 from eva.catalog.models.column_catalog import ColumnCatalogEntry
-from eva.catalog.models.table_catalog import TableCatalogEntry
 
 
 class IndexCatalog(BaseModel):
@@ -30,7 +29,6 @@ class IndexCatalog(BaseModel):
     `_name:` the name of the index.
     `_save_file_path:` the path to the index file on disk
     `_type:` the type of the index (refer to `IndexType`)
-    `_secondary_index_id:` the `_row_id` of the `TableCatalog` entry for the table on which the index is built
     `_feat_column_id:` the `_row_id` of the `ColumnCatalog` entry for the column on which the index is built.
     """
 
@@ -39,12 +37,7 @@ class IndexCatalog(BaseModel):
     _name = Column("name", String(100), unique=True)
     _save_file_path = Column("save_file_path", String(128))
     _type = Column("type", Enum(IndexType), default=Enum)
-    _secondary_index_id = Column(
-        "secondary_index_id", Integer, ForeignKey("table_catalog._row_id")
-    )
     _feat_column_id = Column("column_id", Integer, ForeignKey("column_catalog._row_id"))
-
-    _secondary_index = relationship("TableCatalog")
     _feat_column = relationship("ColumnCatalog")
 
     def __init__(
@@ -52,28 +45,21 @@ class IndexCatalog(BaseModel):
         name: str,
         save_file_path: str,
         type: IndexType,
-        secondary_index_id: int = None,
         feat_column_id: int = None,
     ):
         self._name = name
         self._save_file_path = save_file_path
         self._type = type
-        self._secondary_index_id = secondary_index_id
         self._feat_column_id = feat_column_id
 
     def as_dataclass(self) -> "IndexCatalogEntry":
-        secondary_index = (
-            self._secondary_index.as_dataclass() if self._secondary_index else None
-        )
         feat_column = self._feat_column.as_dataclass() if self._feat_column else None
         return IndexCatalogEntry(
             row_id=self._row_id,
             name=self._name,
             save_file_path=self._save_file_path,
             type=self._type,
-            secondary_index_id=self._secondary_index_id,
             feat_column_id=self._feat_column_id,
-            secondary_index=secondary_index,
             feat_column=feat_column,
         )
 
@@ -88,7 +74,5 @@ class IndexCatalogEntry:
     save_file_path: str
     type: IndexType
     row_id: int = None
-    secondary_index_id: int = None
     feat_column_id: int = None
-    secondary_index: TableCatalogEntry = None
     feat_column: ColumnCatalogEntry = None

--- a/eva/catalog/services/index_catalog_service.py
+++ b/eva/catalog/services/index_catalog_service.py
@@ -35,7 +35,9 @@ class IndexCatalogService(BaseService):
         feat_column: ColumnCatalogEntry,
         udf_signature: str,
     ) -> IndexCatalogEntry:
-        index_entry = IndexCatalog(name, save_file_path, type, feat_column.row_id, udf_signature)
+        index_entry = IndexCatalog(
+            name, save_file_path, type, feat_column.row_id, udf_signature
+        )
         index_entry = index_entry.save()
         return index_entry.as_dataclass()
 

--- a/eva/catalog/services/index_catalog_service.py
+++ b/eva/catalog/services/index_catalog_service.py
@@ -19,7 +19,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from eva.catalog.models.column_catalog import ColumnCatalogEntry
 from eva.catalog.models.index_catalog import IndexCatalog, IndexCatalogEntry
-from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.catalog.services.base_service import BaseService
 from eva.utils.logging_manager import logger
 
@@ -35,9 +34,7 @@ class IndexCatalogService(BaseService):
         type: str,
         feat_column: ColumnCatalogEntry,
     ) -> IndexCatalogEntry:
-        index_entry = IndexCatalog(
-            name, save_file_path, type, feat_column.row_id
-        )
+        index_entry = IndexCatalog(name, save_file_path, type, feat_column.row_id)
         index_entry = index_entry.save()
         return index_entry.as_dataclass()
 

--- a/eva/catalog/services/index_catalog_service.py
+++ b/eva/catalog/services/index_catalog_service.py
@@ -33,11 +33,10 @@ class IndexCatalogService(BaseService):
         name: str,
         save_file_path: str,
         type: str,
-        secondary_index_table: TableCatalogEntry,
         feat_column: ColumnCatalogEntry,
     ) -> IndexCatalogEntry:
         index_entry = IndexCatalog(
-            name, save_file_path, type, secondary_index_table.row_id, feat_column.row_id
+            name, save_file_path, type, feat_column.row_id
         )
         index_entry = index_entry.save()
         return index_entry.as_dataclass()

--- a/eva/catalog/services/index_catalog_service.py
+++ b/eva/catalog/services/index_catalog_service.py
@@ -33,8 +33,9 @@ class IndexCatalogService(BaseService):
         save_file_path: str,
         type: str,
         feat_column: ColumnCatalogEntry,
+        udf_signature: str,
     ) -> IndexCatalogEntry:
-        index_entry = IndexCatalog(name, save_file_path, type, feat_column.row_id)
+        index_entry = IndexCatalog(name, save_file_path, type, feat_column.row_id, udf_signature)
         index_entry = index_entry.save()
         return index_entry.as_dataclass()
 
@@ -54,11 +55,12 @@ class IndexCatalogService(BaseService):
 
     def delete_entry_by_name(self, name: str):
         try:
-            index_record = self.model.query.filter(self.model._name == name).one()
+            index_obj = self.model.query.filter(self.model._name == name).one()
+            index_metadata = index_obj.as_dataclass()
             # clean up the on disk data
-            if os.path.exists(index_record.save_file_path):
-                os.remove(index_record.save_file_path)
-            index_record.delete()
+            if os.path.exists(index_metadata.save_file_path):
+                os.remove(index_metadata.save_file_path)
+            index_obj.delete()
         except Exception:
             logger.exception("Delete index failed for name {}".format(name))
             return False

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -91,7 +91,7 @@ class CreateIndexExecutor(AbstractExecutor):
                 self._get_index_save_path(),
                 self.node.index_type,
                 feat_column,
-                udf_func.signature() if udf_func else None
+                udf_func.signature() if udf_func else None,
             )
 
             yield Batch(

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -55,21 +55,31 @@ class CreateIndexExecutor(AbstractExecutor):
                 col for col in feat_catalog_entry.columns if col.name == feat_col_name
             ][0]
 
+            # Get udf function.
+            udf_func = self.node.udf_func
+
             # Add features to index.
             # TODO: batch size is hardcoded for now.
             index = None
             input_dim = -1
             storage_engine = StorageEngine.factory(feat_catalog_entry)
-            for batch in storage_engine.read(feat_catalog_entry, 1):
-                # Pandas wraps numpy array as an object inside a numpy
-                # array. Use zero index to get the actual numpy array.
-                feat = batch.column_as_numpy_array(feat_col_name)[0]
+            for input_batch in storage_engine.read(feat_catalog_entry, 1):
+                if udf_func:
+                    input_batch.modify_column_alias(feat_catalog_entry.name.lower())
+                    feat_batch = self.node.udf_func.evaluate(input_batch)
+                    feat_batch.drop_column_alias()
+                    input_batch.drop_column_alias()
+                    feat = feat_batch.column_as_numpy_array("features")[0]
+                else:
+                    # Pandas wraps numpy array as an object inside a numpy
+                    # array. Use zero index to get the actual numpy array.
+                    feat = input_batch.column_as_numpy_array(feat_col_name)[0]
                 if index is None:
                     input_dim = feat.shape[-1]
                     index = self._create_index(self.node.index_type, input_dim)
 
                 # Row ID for mapping back to the row.
-                row_id = batch.column_as_numpy_array(IDENTIFIER_COLUMN)[0]
+                row_id = input_batch.column_as_numpy_array(IDENTIFIER_COLUMN)[0]
                 index.add_with_ids(feat, np.array([row_id]))
 
             # Persist index.
@@ -81,6 +91,7 @@ class CreateIndexExecutor(AbstractExecutor):
                 self._get_index_save_path(),
                 self.node.index_type,
                 feat_column,
+                udf_func.signature() if udf_func else None
             )
 
             yield Batch(

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -31,6 +31,18 @@ from eva.storage.storage_engine import StorageEngine
 from eva.utils.logging_manager import logger
 
 
+def create_faiss_index(index_type: IndexType, input_dim: int):
+    # Refernce to Faiss documentation.
+    # IDMap: https://github.com/facebookresearch/faiss/wiki/Pre--and-post-processing#faiss-id-mapping
+    # Other index types: https://github.com/facebookresearch/faiss/wiki/The-index-factory
+
+    if index_type == IndexType.HNSW:
+        # HSNW is the actual index. Faiss also provides
+        # a secondary mapping (IDMap) to map from ID inside index to
+        # our given ID.
+        return faiss.IndexIDMap2(faiss.IndexHNSWFlat(input_dim, 32))
+
+
 class CreateIndexExecutor(AbstractExecutor):
     def __init__(self, node: CreateIndexPlan):
         super().__init__(node)
@@ -45,68 +57,19 @@ class CreateIndexExecutor(AbstractExecutor):
             logger.error(msg)
             raise ExecutorError(msg)
 
-        try:
-            # Get feature tables.
-            feat_catalog_entry = self.node.table_ref.table.table_obj
+        # Get the index type.
+        index_type = self.node.index_type
 
-            # Get feature column.
-            feat_col_name = self.node.col_list[0].name
-            feat_column = [
-                col for col in feat_catalog_entry.columns if col.name == feat_col_name
-            ][0]
+        if IndexType.is_faiss_index_type(index_type):
+            self._create_faiss_index()
+        else:
+            raise ExecutorError("Index type {} is not supported.".format(index_type))
 
-            # Get udf function.
-            udf_func = self.node.udf_func
-
-            # Add features to index.
-            # TODO: batch size is hardcoded for now.
-            index = None
-            input_dim = -1
-            storage_engine = StorageEngine.factory(feat_catalog_entry)
-            for input_batch in storage_engine.read(feat_catalog_entry, 1):
-                if udf_func:
-                    input_batch.modify_column_alias(feat_catalog_entry.name.lower())
-                    feat_batch = self.node.udf_func.evaluate(input_batch)
-                    feat_batch.drop_column_alias()
-                    input_batch.drop_column_alias()
-                    feat = feat_batch.column_as_numpy_array("features")[0]
-                else:
-                    # Pandas wraps numpy array as an object inside a numpy
-                    # array. Use zero index to get the actual numpy array.
-                    feat = input_batch.column_as_numpy_array(feat_col_name)[0]
-                if index is None:
-                    input_dim = feat.shape[-1]
-                    index = self._create_index(self.node.index_type, input_dim)
-
-                # Row ID for mapping back to the row.
-                row_id = input_batch.column_as_numpy_array(IDENTIFIER_COLUMN)[0]
-                index.add_with_ids(feat, np.array([row_id]))
-
-            # Persist index.
-            faiss.write_index(index, self._get_index_save_path())
-
-            # Save to catalog.
-            catalog_manager.insert_index_catalog_entry(
-                self.node.name,
-                self._get_index_save_path(),
-                self.node.index_type,
-                feat_column,
-                udf_func.signature() if udf_func else None,
+        yield Batch(
+            pd.DataFrame(
+                [f"Index {self.node.name} successfully added to the database."]
             )
-
-            yield Batch(
-                pd.DataFrame(
-                    [f"Index {self.node.name} successfully added to the database."]
-                )
-            )
-        except Exception as e:
-            # Roll back in reverse order.
-            # Delete on-disk index.
-            if os.path.exists(self._get_index_save_path()):
-                os.remove(self._get_index_save_path())
-
-            # Throw exception back to user.
-            raise ExecutorError(str(e))
+        )
 
     def _get_index_save_path(self):
         return str(
@@ -148,11 +111,65 @@ class CreateIndexExecutor(AbstractExecutor):
 
     #     return [input_index_io, id_index_io, distance_index_io]
 
-    def _create_index(self, index_type: IndexType, input_dim: int):
-        if index_type == IndexType.HNSW:
-            # HSNW is the actual index. Faiss also provides
-            # a secondary mapping (IDMap) to map from ID inside index to
-            # our given ID.
-            return faiss.IndexIDMap2(faiss.IndexHNSWFlat(input_dim, 32))
-        else:
-            raise ExecutorError(f"Index Type {index_type} is not supported.")
+    def _create_faiss_index(self):
+        try:
+            catalog_manager = CatalogManager()
+
+            # Get feature tables.
+            feat_catalog_entry = self.node.table_ref.table.table_obj
+
+            # Get feature column.
+            feat_col_name = self.node.col_list[0].name
+            feat_column = [
+                col for col in feat_catalog_entry.columns if col.name == feat_col_name
+            ][0]
+
+            # Get udf function.
+            udf_func = self.node.udf_func
+
+            # Add features to index.
+            # TODO: batch size is hardcoded for now.
+            index = None
+            input_dim = -1
+            storage_engine = StorageEngine.factory(feat_catalog_entry)
+            for input_batch in storage_engine.read(feat_catalog_entry, 1):
+                if udf_func:
+                    # Create index through UDF expression.
+                    # UDF(input column) -> 2 dimension feature vector.
+                    input_batch.modify_column_alias(feat_catalog_entry.name.lower())
+                    feat_batch = self.node.udf_func.evaluate(input_batch)
+                    feat_batch.drop_column_alias()
+                    input_batch.drop_column_alias()
+                    feat = feat_batch.column_as_numpy_array("features")[0]
+                else:
+                    # Create index on the feature table direclty.
+                    # Pandas wraps numpy array as an object inside a numpy
+                    # array. Use zero index to get the actual numpy array.
+                    feat = input_batch.column_as_numpy_array(feat_col_name)[0]
+                if index is None:
+                    input_dim = feat.shape[-1]
+                    index = create_faiss_index(self.node.index_type, input_dim)
+
+                # Row ID for mapping back to the row.
+                row_id = input_batch.column_as_numpy_array(IDENTIFIER_COLUMN)[0]
+                index.add_with_ids(feat, np.array([row_id]))
+
+            # Persist index.
+            faiss.write_index(index, self._get_index_save_path())
+
+            # Save to catalog.
+            catalog_manager.insert_index_catalog_entry(
+                self.node.name,
+                self._get_index_save_path(),
+                self.node.index_type,
+                feat_column,
+                udf_func.signature() if udf_func else None,
+            )
+        except Exception as e:
+            # Roll back in reverse order.
+            # Delete on-disk index.
+            if os.path.exists(self._get_index_save_path()):
+                os.remove(self._get_index_save_path())
+
+            # Throw exception back to user.
+            raise ExecutorError(str(e))

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import numpy as np
 from pathlib import Path
 
 import faiss
+import numpy as np
 import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
@@ -142,8 +142,6 @@ class CreateIndexExecutor(AbstractExecutor):
             # HSNW is the actual index. Faiss also provides
             # a secondary mapping (IDMap) to map from ID inside index to
             # our given ID.
-            return faiss.IndexIDMap2(
-                faiss.IndexHNSWFlat(input_dim, 32)
-            )
+            return faiss.IndexIDMap2(faiss.IndexHNSWFlat(input_dim, 32))
         else:
             raise ExecutorError(f"Index Type {index_type} is not supported.")

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import numpy as np
 from pathlib import Path
 
 import faiss
 import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
-from eva.catalog.catalog_type import ColumnType, IndexType, TableType
-from eva.catalog.catalog_utils import xform_column_definitions_to_catalog_entries
+from eva.catalog.catalog_type import IndexType
 from eva.catalog.sql_config import IDENTIFIER_COLUMN
 from eva.configuration.constants import EVA_DEFAULT_DIR, INDEX_DIR
 from eva.executor.abstract_executor import AbstractExecutor
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
-from eva.parser.create_statement import ColConstraintInfo, ColumnDefinition
 from eva.plan_nodes.create_index_plan import CreateIndexPlan
 from eva.storage.storage_engine import StorageEngine
 from eva.utils.logging_manager import logger
@@ -59,8 +58,7 @@ class CreateIndexExecutor(AbstractExecutor):
             # Add features to index.
             # TODO: batch size is hardcoded for now.
             index = None
-            input_dim, num_rows = -1, 0
-            logical_to_row_id = dict()
+            input_dim = -1
             storage_engine = StorageEngine.factory(feat_catalog_entry)
             for batch in storage_engine.read(feat_catalog_entry, 1):
                 # Pandas wraps numpy array as an object inside a numpy
@@ -69,27 +67,10 @@ class CreateIndexExecutor(AbstractExecutor):
                 if index is None:
                     input_dim = feat.shape[-1]
                     index = self._create_index(self.node.index_type, input_dim)
-                index.add(feat)
 
-                # Secondary mapping.
+                # Row ID for mapping back to the row.
                 row_id = batch.column_as_numpy_array(IDENTIFIER_COLUMN)[0]
-                logical_to_row_id[num_rows] = row_id
-
-                num_rows += 1
-
-            # Build secondary index maaping.
-            secondary_index_catalog_entry = self._create_secondary_index_table()
-            storage_engine = StorageEngine.factory(secondary_index_catalog_entry)
-            storage_engine.create(secondary_index_catalog_entry)
-
-            # Write mapping.
-            logical_id, row_id = list(logical_to_row_id.keys()), list(
-                logical_to_row_id.values()
-            )
-            secondary_index = Batch(
-                pd.DataFrame(data={"logical_id": logical_id, "row_id": row_id})
-            )
-            storage_engine.write(secondary_index_catalog_entry, secondary_index)
+                index.add_with_ids(feat, np.array([row_id]))
 
             # Persist index.
             faiss.write_index(index, self._get_index_save_path())
@@ -99,7 +80,6 @@ class CreateIndexExecutor(AbstractExecutor):
                 self.node.name,
                 self._get_index_save_path(),
                 self.node.index_type,
-                secondary_index_catalog_entry,
                 feat_column,
             )
 
@@ -113,22 +93,6 @@ class CreateIndexExecutor(AbstractExecutor):
             # Delete on-disk index.
             if os.path.exists(self._get_index_save_path()):
                 os.remove(self._get_index_save_path())
-
-            # Drop secondary index table.
-            secondary_index_tb_name = "secondary_index_{}_{}".format(
-                self.node.index_type, self.node.name
-            )
-            if catalog_manager.check_table_exists(
-                secondary_index_tb_name,
-            ):
-                secondary_index_catalog_entry = catalog_manager.get_table_catalog_entry(
-                    secondary_index_tb_name
-                )
-                storage_engine = StorageEngine.factory(secondary_index_catalog_entry)
-                storage_engine.drop(secondary_index_catalog_entry)
-                catalog_manager.delete_table_catalog_entry(
-                    secondary_index_catalog_entry
-                )
 
             # Throw exception back to user.
             raise ExecutorError(str(e))
@@ -173,43 +137,13 @@ class CreateIndexExecutor(AbstractExecutor):
 
     #     return [input_index_io, id_index_io, distance_index_io]
 
-    def _create_secondary_index_table(self):
-        # Build secondary index to map from index Logical ID to Row ID.
-        # Use save_file_path's hash value to retrieve the table.
-        catalog_manager = CatalogManager()
-        col_list = [
-            ColumnDefinition(
-                "logical_id",
-                ColumnType.INTEGER,
-                None,
-                None,
-                ColConstraintInfo(unique=True),
-            ),
-            ColumnDefinition(
-                "row_id",
-                ColumnType.INTEGER,
-                None,
-                None,
-                ColConstraintInfo(unique=True),
-            ),
-        ]
-        col_catalog_entries = xform_column_definitions_to_catalog_entries(col_list)
-        catalog_manager = CatalogManager()
-        table_catalog_entry = catalog_manager.insert_table_catalog_entry(
-            "secondary_index_{}_{}".format(self.node.index_type, self.node.name),
-            str(
-                EVA_DEFAULT_DIR
-                / INDEX_DIR
-                / Path("{}_{}.secindex".format(self.node.index_type, self.node.name))
-            ),
-            col_catalog_entries,
-            identifier_column="logical_id",
-            table_type=TableType.STRUCTURED_DATA,
-        )
-        return table_catalog_entry
-
     def _create_index(self, index_type: IndexType, input_dim: int):
         if index_type == IndexType.HNSW:
-            return faiss.IndexHNSWFlat(input_dim, 32)
+            # HSNW is the actual index. Faiss also provides
+            # a secondary mapping (IDMap) to map from ID inside index to
+            # our given ID.
+            return faiss.IndexIDMap2(
+                faiss.IndexHNSWFlat(input_dim, 32)
+            )
         else:
             raise ExecutorError(f"Index Type {index_type} is not supported.")

--- a/eva/optimizer/operators.py
+++ b/eva/optimizer/operators.py
@@ -1095,6 +1095,7 @@ class LogicalCreateIndex(Operator):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         index_type: IndexType,
+        udf_func: FunctionExpression = None,
         children: List = None,
     ):
         super().__init__(OperatorType.LOGICALCREATEINDEX, children)
@@ -1102,6 +1103,7 @@ class LogicalCreateIndex(Operator):
         self._table_ref = table_ref
         self._col_list = col_list
         self._index_type = index_type
+        self._udf_func = udf_func
 
     @property
     def name(self):
@@ -1119,6 +1121,10 @@ class LogicalCreateIndex(Operator):
     def index_type(self):
         return self._index_type
 
+    @property
+    def udf_func(self):
+        return self._udf_func
+
     def __eq__(self, other):
         is_subtree_equal = super().__eq__(other)
         if not isinstance(other, LogicalCreateIndex):
@@ -1129,6 +1135,7 @@ class LogicalCreateIndex(Operator):
             and self.table_ref == other.table_ref
             and self.col_list == other.col_list
             and self.index_type == other.index_type
+            and self.udf_func == other.udf_func
         )
 
     def __hash__(self) -> int:
@@ -1139,6 +1146,7 @@ class LogicalCreateIndex(Operator):
                 self.table_ref,
                 tuple(self.col_list),
                 self.index_type,
+                self.udf_func,
             )
         )
 

--- a/eva/optimizer/rules/rules.py
+++ b/eva/optimizer/rules/rules.py
@@ -541,6 +541,7 @@ class LogicalCreateIndexToFaiss(Rule):
             before.table_ref,
             before.col_list,
             before.index_type,
+            before.udf_func,
         )
         return after
 

--- a/eva/optimizer/statement_to_opr_convertor.py
+++ b/eva/optimizer/statement_to_opr_convertor.py
@@ -313,6 +313,7 @@ class StatementToPlanConvertor:
             statement.table_ref,
             statement.col_list,
             statement.index_type,
+            statement.udf_func,
         )
         self._plan = create_index_opr
 

--- a/eva/parser/create_index_statement.py
+++ b/eva/parser/create_index_statement.py
@@ -15,11 +15,11 @@
 from typing import List
 
 from eva.catalog.catalog_type import IndexType
+from eva.expression.function_expression import FunctionExpression
 from eva.parser.create_statement import ColumnDefinition
 from eva.parser.statement import AbstractStatement
 from eva.parser.table_ref import TableRef
 from eva.parser.types import StatementType
-from eva.expression.function_expression import FunctionExpression
 
 
 class CreateIndexStatement(AbstractStatement):
@@ -40,7 +40,10 @@ class CreateIndexStatement(AbstractStatement):
 
     def __str__(self) -> str:
         print_str = "CREATE INDEX {} ON {} ({}{}) ".format(
-            self._name, self._table_ref, "" if self._udf_func else self._udf_func, tuple(self._col_list)
+            self._name,
+            self._table_ref,
+            "" if self._udf_func else self._udf_func,
+            tuple(self._col_list),
         )
         return print_str
 

--- a/eva/parser/create_index_statement.py
+++ b/eva/parser/create_index_statement.py
@@ -19,6 +19,7 @@ from eva.parser.create_statement import ColumnDefinition
 from eva.parser.statement import AbstractStatement
 from eva.parser.table_ref import TableRef
 from eva.parser.types import StatementType
+from eva.expression.function_expression import FunctionExpression
 
 
 class CreateIndexStatement(AbstractStatement):
@@ -28,16 +29,18 @@ class CreateIndexStatement(AbstractStatement):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         index_type: IndexType,
+        udf_func: FunctionExpression = None,
     ):
         super().__init__(StatementType.CREATE_INDEX)
         self._name = name
         self._table_ref = table_ref
         self._col_list = col_list
         self._index_type = index_type
+        self._udf_func = udf_func
 
     def __str__(self) -> str:
-        print_str = "CREATE INDEX {} ON {} ({}) ".format(
-            self._name, self._table_ref, tuple(self._col_list)
+        print_str = "CREATE INDEX {} ON {} ({}{}) ".format(
+            self._name, self._table_ref, "" if self._udf_func else self._udf_func, tuple(self._col_list)
         )
         return print_str
 
@@ -57,6 +60,10 @@ class CreateIndexStatement(AbstractStatement):
     def index_type(self):
         return self._index_type
 
+    @property
+    def udf_func(self):
+        return self._udf_func
+
     def __eq__(self, other):
         if not isinstance(other, CreateIndexStatement):
             return False
@@ -65,6 +72,7 @@ class CreateIndexStatement(AbstractStatement):
             and self._table_ref == other.table_ref
             and self.col_list == other.col_list
             and self._index_type == other.index_type
+            and self._udf_func == other.udf_func
         )
 
     def __hash__(self) -> int:
@@ -75,5 +83,6 @@ class CreateIndexStatement(AbstractStatement):
                 self._table_ref,
                 tuple(self.col_list),
                 self._index_type,
+                self._udf_func,
             )
         )

--- a/eva/parser/eva.lark
+++ b/eva/parser/eva.lark
@@ -18,7 +18,7 @@ utility_statement: describe_statement | show_statement | help_statement | explai
 
 create_database: CREATE DATABASE if_not_exists? uid
 
-create_index: CREATE INDEX uid ON table_name ("(" uid_list ")") index_type?
+create_index: CREATE INDEX uid ON table_name index_elem index_type?
 
 create_table: CREATE TABLE if_not_exists? table_name create_definitions 
     
@@ -40,6 +40,9 @@ udf_type: uid
 udf_impl: string_literal
 
 index_type: USING HNSW
+
+index_elem: ("(" uid_list ")"
+          | "(" function_call ")")
 
 create_definitions: "(" create_definition ("," create_definition)* ")"
 

--- a/eva/parser/lark_visitor/_create_statements.py
+++ b/eva/parser/lark_visitor/_create_statements.py
@@ -16,9 +16,9 @@
 from lark import Tree
 
 from eva.catalog.catalog_type import ColumnType, IndexType, NdArrayType
+from eva.expression.tuple_value_expression import TupleValueExpression
 from eva.parser.create_index_statement import CreateIndexStatement
 from eva.parser.create_mat_view_statement import CreateMaterializedViewStatement
-from eva.expression.tuple_value_expression import TupleValueExpression
 from eva.parser.create_statement import (
     ColConstraintInfo,
     ColumnDefinition,
@@ -307,7 +307,10 @@ class CreateTable:
             index_elem = [index_elem]
 
         col_list = [
-            ColumnDefinition(tv_expr.col_name, None, None, None) for tv_expr in index_elem
+            ColumnDefinition(tv_expr.col_name, None, None, None)
+            for tv_expr in index_elem
         ]
 
-        return CreateIndexStatement(index_name, table_ref, col_list, index_type, udf_func)
+        return CreateIndexStatement(
+            index_name, table_ref, col_list, index_type, udf_func
+        )

--- a/eva/plan_nodes/create_index_plan.py
+++ b/eva/plan_nodes/create_index_plan.py
@@ -16,6 +16,7 @@ from typing import List
 
 from eva.catalog.catalog_type import IndexType
 from eva.parser.create_statement import ColumnDefinition
+from eva.expression.function_expression import FunctionExpression
 from eva.parser.table_ref import TableRef
 from eva.plan_nodes.abstract_plan import AbstractPlan
 from eva.plan_nodes.types import PlanOprType
@@ -28,12 +29,14 @@ class CreateIndexPlan(AbstractPlan):
         table_ref: TableRef,
         col_list: List[ColumnDefinition],
         index_type: IndexType,
+        udf_func: FunctionExpression = None,
     ):
         super().__init__(PlanOprType.CREATE_INDEX)
         self._name = name
         self._table_ref = table_ref
         self._col_list = col_list
         self._index_type = index_type
+        self._udf_func = udf_func
 
     @property
     def name(self):
@@ -51,15 +54,21 @@ class CreateIndexPlan(AbstractPlan):
     def index_type(self):
         return self._index_type
 
+    @property
+    def udf_func(self):
+        return self._udf_func
+
     def __str__(self):
         return "CreateIndexPlan(name={}, \
             table_ref={}, \
             col_list={}, \
-            index_type={})".format(
+            index_type={}, \
+            {})".format(
             self._name,
             self._table_ref,
             tuple(self._col_list),
             self._index_type,
+            "" if not self._udf_func else "udf_func={}".format(self._udf_func),
         )
 
     def __hash__(self) -> int:
@@ -70,5 +79,6 @@ class CreateIndexPlan(AbstractPlan):
                 self.table_ref,
                 tuple(self.col_list),
                 self.index_type,
+                self.udf_func,
             )
         )

--- a/eva/plan_nodes/create_index_plan.py
+++ b/eva/plan_nodes/create_index_plan.py
@@ -15,8 +15,8 @@
 from typing import List
 
 from eva.catalog.catalog_type import IndexType
-from eva.parser.create_statement import ColumnDefinition
 from eva.expression.function_expression import FunctionExpression
+from eva.parser.create_statement import ColumnDefinition
 from eva.parser.table_ref import TableRef
 from eva.plan_nodes.abstract_plan import AbstractPlan
 from eva.plan_nodes.types import PlanOprType

--- a/eva/udfs/udf_bootstrap_queries.py
+++ b/eva/udfs/udf_bootstrap_queries.py
@@ -41,7 +41,7 @@ DummyMultiObjectDetector_udf_query = """CREATE UDF
 DummyFeatureExtractor_udf_query = """CREATE UDF
                   IF NOT EXISTS DummyFeatureExtractor
                   INPUT (Frame_Array NDARRAY UINT8(3, ANYDIM, ANYDIM))
-                  OUTPUT (features NDARRAY UINT8(3, ANYDIM, ANYDIM))
+                  OUTPUT (features NDARRAY FLOAT32(1, ANYDIM))
                   TYPE Classification
                   IMPL '{}/../test/util.py';
         """.format(

--- a/test/catalog/services/test_index_catalog_service.py
+++ b/test/catalog/services/test_index_catalog_service.py
@@ -67,7 +67,9 @@ class IndexCatalogServiceTest(TestCase):
             service.delete_entry_by_name("index_name")
             mocked.query.filter.assert_called_with(mocked._name == INDEX_NAME)
             index_obj.delete.assert_called_once()
-            mock_os_remove.assert_called_once_with(index_obj.as_dataclass().save_file_path)
+            mock_os_remove.assert_called_once_with(
+                index_obj.as_dataclass().save_file_path
+            )
 
         with patch(PATCH_PATH) as mocked:
             service = IndexCatalogService()

--- a/test/catalog/services/test_index_catalog_service.py
+++ b/test/catalog/services/test_index_catalog_service.py
@@ -67,7 +67,7 @@ class IndexCatalogServiceTest(TestCase):
             service.delete_entry_by_name("index_name")
             mocked.query.filter.assert_called_with(mocked._name == INDEX_NAME)
             index_obj.delete.assert_called_once()
-            mock_os_remove.assert_called_once_with(index_obj.save_file_path)
+            mock_os_remove.assert_called_once_with(index_obj.as_dataclass().save_file_path)
 
         with patch(PATCH_PATH) as mocked:
             service = IndexCatalogService()

--- a/test/integration_tests/test_create_index_executor.py
+++ b/test/integration_tests/test_create_index_executor.py
@@ -39,11 +39,7 @@ class CreateIndexTest(unittest.TestCase):
         return str(
             EVA_DEFAULT_DIR
             / INDEX_DIR
-            / Path(
-                "{}_{}.index".format(
-                    "HNSW", "testCreateIndexName"
-                )
-            )
+            / Path("{}_{}.index".format("HNSW", "testCreateIndexName"))
         )
 
     @classmethod
@@ -138,6 +134,4 @@ class CreateIndexTest(unittest.TestCase):
             execute_query_fetch_all(query)
 
         # Check faulty index is not persisted on the disk
-        self.assertFalse(os.path.exists(
-            self._index_save_path()
-        ))
+        self.assertFalse(os.path.exists(self._index_save_path()))

--- a/test/integration_tests/test_create_index_executor.py
+++ b/test/integration_tests/test_create_index_executor.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 from pathlib import Path
+from test.util import load_inbuilt_udfs
 
 import faiss
 import numpy as np
@@ -33,7 +34,6 @@ from eva.parser.create_statement import ColumnDefinition
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
 from eva.utils.generic_utils import generate_file_path
-from test.util import load_inbuilt_udfs
 
 
 class CreateIndexTest(unittest.TestCase):
@@ -179,13 +179,18 @@ class CreateIndexTest(unittest.TestCase):
             index_catalog_entry.save_file_path,
             self._index_save_path(),
         )
-        self.assertEqual(index_catalog_entry.udf_signature, "DummyFeatureExtractor(testCreateIndexInputTable.input)")
+        self.assertEqual(
+            index_catalog_entry.udf_signature,
+            "DummyFeatureExtractor(testCreateIndexInputTable.input)",
+        )
 
         # Test referenced column.
         input_table_entry = CatalogManager().get_table_catalog_entry(
             "testCreateIndexInputTable"
         )
-        input_column = [col for col in input_table_entry.columns if col.name == "input"][0]
+        input_column = [
+            col for col in input_table_entry.columns if col.name == "input"
+        ][0]
         self.assertEqual(index_catalog_entry.feat_column_id, input_column.row_id)
         self.assertEqual(index_catalog_entry.feat_column, input_column)
 

--- a/test/integration_tests/test_create_index_executor.py
+++ b/test/integration_tests/test_create_index_executor.py
@@ -24,14 +24,16 @@ from mock import patch
 from eva.catalog.catalog_manager import CatalogManager
 from eva.catalog.catalog_type import ColumnType, IndexType, NdArrayType, TableType
 from eva.catalog.catalog_utils import xform_column_definitions_to_catalog_entries
+from eva.catalog.sql_config import IDENTIFIER_COLUMN
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_DEFAULT_DIR, INDEX_DIR
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
-from eva.parser.create_statement import ColConstraintInfo, ColumnDefinition
+from eva.parser.create_statement import ColumnDefinition
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
 from eva.utils.generic_utils import generate_file_path
+from test.util import load_inbuilt_udfs
 
 
 class CreateIndexTest(unittest.TestCase):
@@ -50,48 +52,72 @@ class CreateIndexTest(unittest.TestCase):
         # Reset catalog.
         CatalogManager().reset()
 
-        # Create feature vector.
+        load_inbuilt_udfs()
+
+        # Create feature vector table and raw input table.
         feat1 = np.array([[0, 0, 0]]).astype(np.float32)
         feat2 = np.array([[100, 100, 100]]).astype(np.float32)
         feat3 = np.array([[200, 200, 200]]).astype(np.float32)
 
+        input1 = np.array([[0, 0, 0]]).astype(np.uint8)
+        input2 = np.array([[100, 100, 100]]).astype(np.uint8)
+        input3 = np.array([[200, 200, 200]]).astype(np.uint8)
+
         # Create table.
-        col_list = [
-            ColumnDefinition(
-                "feat_id",
-                ColumnType.INTEGER,
-                None,
-                None,
-                ColConstraintInfo(unique=True),
-            ),
+        feat_col_list = [
             ColumnDefinition("feat", ColumnType.NDARRAY, NdArrayType.FLOAT32, (1, 3)),
         ]
-        col_entries = xform_column_definitions_to_catalog_entries(col_list)
+        feat_col_entries = xform_column_definitions_to_catalog_entries(feat_col_list)
 
-        tb_entry = CatalogManager().insert_table_catalog_entry(
+        input_col_list = [
+            ColumnDefinition("input", ColumnType.NDARRAY, NdArrayType.UINT8, (1, 3)),
+        ]
+        input_col_entries = xform_column_definitions_to_catalog_entries(input_col_list)
+
+        feat_tb_entry = CatalogManager().insert_table_catalog_entry(
             "testCreateIndexFeatTable",
             str(generate_file_path("testCreateIndexFeatTable")),
-            col_entries,
-            identifier_column="feat_id",
+            feat_col_entries,
+            identifier_column=IDENTIFIER_COLUMN,
             table_type=TableType.STRUCTURED_DATA,
         )
-        storage_engine = StorageEngine.factory(tb_entry)
-        storage_engine.create(tb_entry)
+        storage_engine = StorageEngine.factory(feat_tb_entry)
+        storage_engine.create(feat_tb_entry)
+
+        input_tb_entry = CatalogManager().insert_table_catalog_entry(
+            "testCreateIndexInputTable",
+            str(generate_file_path("testCreateIndexInputTable")),
+            input_col_entries,
+            identifier_column=IDENTIFIER_COLUMN,
+            table_type=TableType.STRUCTURED_DATA,
+        )
+        storage_engine = StorageEngine.factory(input_tb_entry)
+        storage_engine.create(input_tb_entry)
 
         # Create pandas dataframe.
-        batch_data = Batch(
+        feat_batch_data = Batch(
             pd.DataFrame(
                 data={
-                    "feat_id": [0, 1, 2],
                     "feat": [feat1, feat2, feat3],
                 }
             )
         )
-        storage_engine.write(tb_entry, batch_data)
+        storage_engine.write(feat_tb_entry, feat_batch_data)
+
+        input_batch_data = Batch(
+            pd.DataFrame(
+                data={
+                    "input": [input1, input2, input3],
+                }
+            )
+        )
+        storage_engine.write(input_tb_entry, input_batch_data)
 
     @classmethod
     def tearDownClass(cls):
         query = "DROP TABLE testCreateIndexFeatTable;"
+        execute_query_fetch_all(query)
+        query = "DROP TABLE testCreateIndexInputTable;"
         execute_query_fetch_all(query)
 
     def test_should_create_index(self):
@@ -106,6 +132,10 @@ class CreateIndexTest(unittest.TestCase):
         self.assertEqual(
             index_catalog_entry.save_file_path,
             self._index_save_path(),
+        )
+        self.assertEqual(
+            index_catalog_entry.udf_signature,
+            None,
         )
 
         # Test referenced column.
@@ -135,3 +165,35 @@ class CreateIndexTest(unittest.TestCase):
 
         # Check faulty index is not persisted on the disk
         self.assertFalse(os.path.exists(self._index_save_path()))
+
+    def test_should_create_index_with_udf(self):
+        query = "CREATE INDEX testCreateIndexName ON testCreateIndexInputTable (DummyFeatureExtractor(input)) USING HNSW;"
+        execute_query_fetch_all(query)
+
+        # Test index udf signature.
+        index_catalog_entry = CatalogManager().get_index_catalog_entry_by_name(
+            "testCreateIndexName"
+        )
+        self.assertEqual(index_catalog_entry.type, IndexType.HNSW)
+        self.assertEqual(
+            index_catalog_entry.save_file_path,
+            self._index_save_path(),
+        )
+        self.assertEqual(index_catalog_entry.udf_signature, "DummyFeatureExtractor(testCreateIndexInputTable.input)")
+
+        # Test referenced column.
+        input_table_entry = CatalogManager().get_table_catalog_entry(
+            "testCreateIndexInputTable"
+        )
+        input_column = [col for col in input_table_entry.columns if col.name == "input"][0]
+        self.assertEqual(index_catalog_entry.feat_column_id, input_column.row_id)
+        self.assertEqual(index_catalog_entry.feat_column, input_column)
+
+        # Test on disk index.
+        index = faiss.read_index(index_catalog_entry.save_file_path)
+        distance, row_id = index.search(np.array([[0, 0, 0]]).astype(np.float32), 1)
+        self.assertEqual(distance[0][0], 0)
+        self.assertEqual(row_id[0][0], 1)
+
+        # Cleanup.
+        CatalogManager().drop_index_catalog_entry("testCreateIndexName")

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -70,7 +70,9 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(actual_stmt, expected_stmt)
 
         # create index on UDF expression
-        create_index_query = "CREATE INDEX testindex ON MyVideo (FeatureExtractor(featCol)) USING HNSW;"
+        create_index_query = (
+            "CREATE INDEX testindex ON MyVideo (FeatureExtractor(featCol)) USING HNSW;"
+        )
         eva_stmt_list = parser.parse(create_index_query)
 
         # check stmt itself
@@ -79,9 +81,7 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(eva_stmt_list[0].stmt_type, StatementType.CREATE_INDEX)
 
         func_expr = FunctionExpression(None, "FeatureExtractor")
-        func_expr.append_child(
-            TupleValueExpression("featCol")
-        )
+        func_expr.append_child(TupleValueExpression("featCol"))
         expected_stmt = CreateIndexStatement(
             "testindex",
             TableRef(TableInfo("MyVideo")),

--- a/test/parser/test_parser.py
+++ b/test/parser/test_parser.py
@@ -69,6 +69,31 @@ class ParserTests(unittest.TestCase):
         actual_stmt = eva_stmt_list[0]
         self.assertEqual(actual_stmt, expected_stmt)
 
+        # create index on UDF expression
+        create_index_query = "CREATE INDEX testindex ON MyVideo (FeatureExtractor(featCol)) USING HNSW;"
+        eva_stmt_list = parser.parse(create_index_query)
+
+        # check stmt itself
+        self.assertIsInstance(eva_stmt_list, list)
+        self.assertEqual(len(eva_stmt_list), 1)
+        self.assertEqual(eva_stmt_list[0].stmt_type, StatementType.CREATE_INDEX)
+
+        func_expr = FunctionExpression(None, "FeatureExtractor")
+        func_expr.append_child(
+            TupleValueExpression("featCol")
+        )
+        expected_stmt = CreateIndexStatement(
+            "testindex",
+            TableRef(TableInfo("MyVideo")),
+            [
+                ColumnDefinition("featCol", None, None, None),
+            ],
+            IndexType.HNSW,
+            func_expr,
+        )
+        actual_stmt = eva_stmt_list[0]
+        self.assertEqual(actual_stmt, expected_stmt)
+
     @unittest.skip("Skip parser exception handling testcase, moved to binder")
     def test_create_index_exception_statement(self):
         parser = Parser()

--- a/test/util.py
+++ b/test/util.py
@@ -458,7 +458,9 @@ class DummyFeatureExtractor(AbstractClassifierUDF):
 
         def _extract_feature(row: pd.Series):
             feat_input = row[0]
-            return feat_input.astype(np.float32)
+            feat_input = feat_input.reshape(1, -1)
+            feat_input = feat_input.astype(np.float32)
+            return feat_input
 
         ret = pd.DataFrame()
         ret["features"] = df.apply(_extract_feature, axis=1)


### PR DESCRIPTION
* Remove secondary index maintained by ourselves. Instead, we now use `IDMap` provided by the FAISS library, which is also faster in terms of performance.
* Add support of creating index on UDF expression directly. Along with that, add udf signature as part of the index catalog, so the expression can be matched again when index is used later. 