### PR TITLE
fix: Circle CI error

### DIFF
--- a/test/executor/test_load_executor.py
+++ b/test/executor/test_load_executor.py
@@ -104,7 +104,7 @@ class LoadExecutorTest(unittest.TestCase):
         load_executor = LoadDataExecutor(plan)
         batch = next(load_executor.exec())
         catalog_mock.assert_called_once_with("dummy", None)
-        factory_mock.return_value.write.has_calls(
+        factory_mock.return_value.write.assert_has_calls(
             call(table_obj, batch_frames[0]),
             call(table_obj, batch_frames[1]),
         )

--- a/test/executor/test_load_executor.py
+++ b/test/executor/test_load_executor.py
@@ -16,7 +16,7 @@ import unittest
 from test.util import create_sample_csv, file_remove
 
 import pandas as pd
-from mock import MagicMock, call, patch
+from mock import MagicMock, patch
 
 from eva.executor.executor_utils import ExecutorError
 from eva.executor.load_executor import LoadDataExecutor
@@ -72,8 +72,6 @@ class LoadExecutorTest(unittest.TestCase):
     def test_should_call_csv_reader_and_storage_engine(
         self, factory_mock, catalog_mock
     ):
-        batch_frames = [list(range(5))] * 2
-
         # creates a dummy.csv
         create_sample_csv()
 
@@ -104,10 +102,7 @@ class LoadExecutorTest(unittest.TestCase):
         load_executor = LoadDataExecutor(plan)
         batch = next(load_executor.exec())
         catalog_mock.assert_called_once_with("dummy", None)
-        factory_mock.return_value.write.assert_has_calls(
-            call(table_obj, batch_frames[0]),
-            call(table_obj, batch_frames[1]),
-        )
+        self.assertEqual(factory_mock.return_value.write.call_args.args[0], table_obj)
 
         # Note: We call exec() from the child classes.
         self.assertEqual(

--- a/test/test_eva_cmd_client.py
+++ b/test/test_eva_cmd_client.py
@@ -28,7 +28,7 @@ class CMDClientTest(unittest.TestCase):
 
         with mock.patch.object(sys, "argv", ["test"]):
             main()
-        mock_client.called_once_with("0.0.0.0", 5432)
+        mock_client.assert_called_once_with("0.0.0.0", 5432)
 
     def test_parse_args(self):
         from eva.eva_cmd_client import parse_args

--- a/test/test_eva_cmd_client.py
+++ b/test/test_eva_cmd_client.py
@@ -28,7 +28,7 @@ class CMDClientTest(unittest.TestCase):
 
         with mock.patch.object(sys, "argv", ["test"]):
             main()
-        mock_client.assert_called_once_with("0.0.0.0", 5432)
+        mock_client.assert_called_once_with(host="0.0.0.0", port=5432)
 
     def test_parse_args(self):
         from eva.eva_cmd_client import parse_args


### PR DESCRIPTION
Circle CI is failing due to test cases without assertions.

```
FAILED test/test_eva_cmd_client.py::CMDClientTest::test_main - AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
FAILED test/executor/test_load_executor.py::LoadExecutorTest::test_should_call_csv_reader_and_storage_engine - AttributeError: 'has_calls' is not a valid assertion. Use a spec for the mock if 'has_calls' is meant to be an attribute.
= 2 failed, 405 passed, 9 skipped, 4 deselected, 38 warnings in 680.68s (0:11:20) =
PYTEST CODE: --|1|-- FAILURE

Exited with code exit status 1
```