### PR TITLE
fix: debugging issue in yolov5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [Breaking Changes]
 ### [Added]
 ### [Changed]
+
+* PR #581: fix: debugging issuse in yolov5
+
 ### [Deprecated]
 ### [Removed]
 

--- a/eva/udfs/yolo_object_detector.py
+++ b/eva/udfs/yolo_object_detector.py
@@ -44,7 +44,7 @@ class YoloV5(PytorchAbstractClassifierUDF):
 
     def setup(self, threshold=0.85):
         self.threshold = threshold
-        self.model = torch.hub.load('ultralytics/yolov5', 'yolov5s', verbose=False)
+        self.model = torch.hub.load("ultralytics/yolov5", "yolov5s", verbose=False)
 
     @property
     def input_format(self) -> FrameInfo:

--- a/eva/udfs/yolo_object_detector.py
+++ b/eva/udfs/yolo_object_detector.py
@@ -51,7 +51,7 @@ class YoloV5(PytorchAbstractClassifierUDF):
 
     def setup(self, threshold=0.85):
         self.threshold = threshold
-        self.model = yolov5.load("yolov5s.pt", verbose=False)
+        self.model = torch.hub.load('ultralytics/yolov5', 'yolov5s', verbose=False)
 
     @property
     def input_format(self) -> FrameInfo:

--- a/eva/udfs/yolo_object_detector.py
+++ b/eva/udfs/yolo_object_detector.py
@@ -29,13 +29,6 @@ except ImportError as e:
         f"Failed to import with error {e}, \
         please try `pip install torch`"
     )
-try:
-    import yolov5
-except ImportError as e:
-    raise ImportError(
-        f"Failed to import with error {e}, \
-        please try `pip install yolov5`"
-    )
 
 
 class YoloV5(PytorchAbstractClassifierUDF):

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ udf_libs = [
     "facenet-pytorch>=2.5.2", # FACE DETECTION
     "easyocr>=1.5.0",         # OCR EXTRACTION
     "ipython",
+    "yolov5<=7.0.6"           # OBJECT DETECTION
     "detoxify"                # TEXT TOXICITY CLASSIFICATION
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ udf_libs = [
     "facenet-pytorch>=2.5.2", # FACE DETECTION
     "easyocr>=1.5.0",         # OCR EXTRACTION
     "ipython",
-    "yolov5<=7.0.6"           # OBJECT DETECTION
+    "yolov5<=7.0.6",           # OBJECT DETECTION
     "detoxify"                # TEXT TOXICITY CLASSIFICATION
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ udf_libs = [
     "facenet-pytorch>=2.5.2", # FACE DETECTION
     "easyocr>=1.5.0",         # OCR EXTRACTION
     "ipython",
-    "yolov5",                 # OBJECT DETECION
     "detoxify"                # TEXT TOXICITY CLASSIFICATION
 ]
 


### PR DESCRIPTION
Should fix the `models.yolo` not found error found when running debugger on eva.
remove `yolov5-pip` package and instead uses `torch.hub` for yolov5 model.