### PR TITLE
feat: Add UDF Cost Catalog

### DIFF
--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -241,12 +241,7 @@ class CatalogManager(object):
     "udf cost catalog services"
 
     def insert_udf_cost_catalog_entry(
-        self,
-        name: str,
-        type: str,
-        cost: int, 
-        frame_count: int,
-        resolution: int
+        self, name: str, type: str, cost: int, frame_count: int, resolution: int
     ) -> UdfCostCatalogEntry:
         """Inserts a UDF cost catalog entry.
         It persists the entry to the database.
@@ -255,7 +250,7 @@ class CatalogManager(object):
             name(str): name of the udf
             type(str): what kind of udf operator like classification,
                                                         detection etc
-            cost(int): cost of this UDF 
+            cost(int): cost of this UDF
             frame_count(int): count of the frames used for this cost estimation
             resolution(int): resolution of the frames used for this estimation
 
@@ -263,7 +258,9 @@ class CatalogManager(object):
             The persisted UdfCostCatalogEntry object.
         """
 
-        udf_entry = self._udf_cost_catlog_service.insert_entry(name, type, cost, frame_count, resolution)
+        udf_entry = self._udf_cost_catlog_service.insert_entry(
+            name, type, cost, frame_count, resolution
+        )
         return udf_entry
 
     "UdfIO services"

--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -26,11 +26,13 @@ from eva.catalog.models.column_catalog import ColumnCatalogEntry
 from eva.catalog.models.index_catalog import IndexCatalogEntry
 from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.catalog.models.udf_catalog import UdfCatalogEntry
+from eva.catalog.models.udf_cost_catalog import UdfCostCatalogEntry
 from eva.catalog.models.udf_io_catalog import UdfIOCatalogEntry
 from eva.catalog.services.column_catalog_service import ColumnCatalogService
 from eva.catalog.services.index_catalog_service import IndexCatalogService
 from eva.catalog.services.table_catalog_service import TableCatalogService
 from eva.catalog.services.udf_catalog_service import UdfCatalogService
+from eva.catalog.services.udf_cost_catalog_service import UdfCostCatalogService
 from eva.catalog.services.udf_io_catalog_service import UdfIOCatalogService
 from eva.catalog.sql_config import IDENTIFIER_COLUMN
 from eva.parser.create_statement import ColumnDefinition
@@ -54,6 +56,7 @@ class CatalogManager(object):
         self._table_catalog_service: TableCatalogService = TableCatalogService()
         self._column_service: ColumnCatalogService = ColumnCatalogService()
         self._udf_service: UdfCatalogService = UdfCatalogService()
+        self._udf_cost_catlog_service: UdfCostCatalogService = UdfCostCatalogService()
         self._udf_io_service: UdfIOCatalogService = UdfIOCatalogService()
         self._index_service: IndexCatalogService = IndexCatalogService()
 
@@ -234,6 +237,34 @@ class CatalogManager(object):
 
     def get_all_udf_catalog_entries(self):
         return self._udf_service.get_all_entries()
+
+    "udf cost catalog services"
+
+    def insert_udf_cost_catalog_entry(
+        self,
+        name: str,
+        type: str,
+        cost: int, 
+        frame_count: int,
+        resolution: int
+    ) -> UdfCostCatalogEntry:
+        """Inserts a UDF cost catalog entry.
+        It persists the entry to the database.
+
+        Arguments:
+            name(str): name of the udf
+            type(str): what kind of udf operator like classification,
+                                                        detection etc
+            cost(int): cost of this UDF 
+            frame_count(int): count of the frames used for this cost estimation
+            resolution(int): resolution of the frames used for this estimation
+
+        Returns:
+            The persisted UdfCostCatalogEntry object.
+        """
+
+        udf_entry = self._udf_cost_catlog_service.insert_entry(name, type, cost, frame_count, resolution)
+        return udf_entry
 
     "UdfIO services"
 

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -41,7 +41,7 @@ class UdfCatalog(BaseModel):
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
-    _name2 = relationship("UdfCostCatlog")
+    _name = relationship("UdfCatlog", back_populates="udf_cost_catalog._name")
 
     def __init__(self, name: str, impl_file_path: str, type: str, checksum: str):
         self._name = name

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -36,7 +36,7 @@ class UdfCatalog(BaseModel):
     _type = Column("type", String(100))
     _checksum = Column("checksum", String(512))
 
-    # UdfIOCatalog stroing the input/output attributes of the udf
+    # UdfIOCatalog storing the input/output attributes of the udf
     _attributes = relationship(
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -41,9 +41,7 @@ class UdfCatalog(BaseModel):
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
-    _name2 = relationship(
-        "UdfCostCatlog", back_populates="_name3", cascade="all, delete, delete-orphan"
-    )
+    _name2 = relationship("UdfCostCatlog")
 
     def __init__(self, name: str, impl_file_path: str, type: str, checksum: str):
         self._name = name

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -41,6 +41,10 @@ class UdfCatalog(BaseModel):
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
+    _name = relationship(
+        "UdfCostCatlog", back_populates="_name", cascade="all, delete, delete-orphan"
+    )
+
     def __init__(self, name: str, impl_file_path: str, type: str, checksum: str):
         self._name = name
         self._impl_file_path = impl_file_path

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -41,7 +41,7 @@ class UdfCatalog(BaseModel):
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
-    _name = relationship("UdfCatlog", back_populates="udf_cost_catalog._name")
+    _name = relationship("UdfCostCatalog", back_populates="udf_cost_catalog._name")
 
     def __init__(self, name: str, impl_file_path: str, type: str, checksum: str):
         self._name = name

--- a/eva/catalog/models/udf_catalog.py
+++ b/eva/catalog/models/udf_catalog.py
@@ -41,8 +41,8 @@ class UdfCatalog(BaseModel):
         "UdfIOCatalog", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
-    _name = relationship(
-        "UdfCostCatlog", back_populates="_name", cascade="all, delete, delete-orphan"
+    _name2 = relationship(
+        "UdfCostCatlog", back_populates="_name3", cascade="all, delete, delete-orphan"
     )
 
     def __init__(self, name: str, impl_file_path: str, type: str, checksum: str):

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -43,7 +43,7 @@ class UdfCostCatalog(BaseModel):
     _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
     """
 
-    _name = relationship("UdfCatlog", back_populates="udf_catalog._name")
+    _name = relationship("UdfCatalog", back_populates="udf_catalog._name")
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+# Copyright 2018-2022 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass, field
+from typing import List
+
+from sqlalchemy import Column, String, Integer
+from sqlalchemy.orm import relationship
+
+from eva.catalog.models.base_model import BaseModel
+
+
+class UdfCostCatalog(BaseModel):
+    """The `UdfCostCatalog` catalog stores information about the runtime of user-defined functions (UDFs)
+    in the system. It maintains the following information for each UDF. 
+    TODO: add params 
+    
+    """
+
+    __tablename__ = "udf_cost_catalog"
+    
+    _type = Column("type", String(100))
+    _cost = Column("cost", Integer())
+    _frame_count  = Column("frame_count", Integer())
+    _resolution = Column("resolution", Integer())
+    
+    # TODO: Add hardware information - GPU information etc. - It can be its own table. 
+    
+    # UdfCatalog storing the input/output attributes of the udf
+    # _name = relationship(
+    #     "UdfCatlog", back_populates="_name", cascade="all, delete, delete-orphan"
+    # )
+
+    _name = Column("name", String(100))
+
+    def __init__(self, name: str, type: str, cost: int, frame_count: int, resolution: int):
+        self._name = name
+        self._type = type 
+        self._cost = cost 
+        self._frame_count = frame_count
+        self._resolution = resolution
+
+    def as_dataclass(self) -> "UdfCostCatalogEntry":
+        args = []
+        outputs = []
+        return UdfCostCatalog(
+            name=self._name,
+            type=self._type,
+            cost=self._cost, 
+            frame_count=self._frame_count,
+            resolution=self._resolution
+        )
+
+
+@dataclass(unsafe_hash=True)
+class UdfCostCatalogEntry:
+    """Dataclass representing an entry in the `UdfCostCatalog`.
+    This is done to ensure we don't expose the sqlalchemy dependencies beyond catalog service. Further, sqlalchemy does not allow sharing of objects across threads.
+    """
+
+    name: str
+    impl_file_path: str
+    type: str
+    row_id: int 
+    thorughput_cost: int = None
+
+    def display_format(self):
+        # TODO: figure out what needs to be returned in the display format 
+        data_type = self.type.name
+
+        return {"name": self.name, "data_type": data_type}

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from dataclasses import dataclass
 
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, ForeignKey, Integer, String
 
 from eva.catalog.models.base_model import BaseModel
 
@@ -24,8 +24,11 @@ from eva.catalog.models.base_model import BaseModel
 class UdfCostCatalog(BaseModel):
     """The `UdfCostCatalog` catalog stores information about the runtime of user-defined functions (UDFs)
     in the system. It maintains the following information for each UDF.
-    TODO: add params
-
+    `_cost:` name of the UDF
+    `_cost:` cost of this UDF
+    `_type:` an optional tag associated with the UDF (useful for grouping similar UDFs, such as multiple object detection UDFs)
+    `_frame_count:` number of frames used to calculate the cost
+    `_resolution:` resolution of the video
     """
 
     __tablename__ = "udf_cost_catalog"
@@ -37,12 +40,8 @@ class UdfCostCatalog(BaseModel):
 
     # TODO: Add hardware information - GPU information etc. - It can be its own table.
 
-    # TODO: UdfCatalog storing the input/output attributes of the udf
-    # _name = relationship(
-    #     "UdfCatlog", back_populates="_name", cascade="all, delete, delete-orphan"
-    # )
-
-    _name = Column("name", String(100))
+    # _name = relationship("UdfCatlog", back_populates="_name")
+    _name = Column("name", Integer, ForeignKey("udf_catalog.name"))
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -39,9 +39,9 @@ class UdfCostCatalog(BaseModel):
     _resolution = Column("resolution", Integer())
 
     # TODO: Add hardware information - GPU information etc. - It can be its own table.
-
+    # TODO: Add relation to UdfCatalog table as one of below:
     # _name = relationship("UdfCatlog", back_populates="_name")
-    _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
+    # _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int
@@ -75,7 +75,6 @@ class UdfCostCatalogEntry:
     thorughput_cost: int = None
 
     def display_format(self):
-        # TODO: figure out what needs to be returned in the display format
         data_type = self.type.name
 
         return {"name": self.name, "data_type": data_type}

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -43,7 +43,7 @@ class UdfCostCatalog(BaseModel):
     _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
     """
 
-    _name3 = relationship("UdfCatlog", back_populates="_name2")
+    _name = relationship("UdfCatlog", back_populates="udf_catalog._name")
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -36,6 +36,7 @@ class UdfCostCatalog(BaseModel):
     _cost = Column("cost", Integer())
     _frame_count = Column("frame_count", Integer())
     _resolution = Column("resolution", Integer())
+    _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
 
     """
     TODO: Add hardware information - GPU information etc. - It can be its own table.

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -38,7 +38,7 @@ class UdfCostCatalog(BaseModel):
     _frame_count = Column("frame_count", Integer())
     _resolution = Column("resolution", Integer())
 
-    """ 
+    """
     TODO: Add hardware information - GPU information etc. - It can be its own table.
     TODO: Add relation to UdfCatalog table as one of below:
     _name = relationship("UdfCatlog", back_populates="_name")

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from dataclasses import dataclass
 
-from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy import Column, Integer, String
 
 from eva.catalog.models.base_model import BaseModel
 
@@ -38,10 +38,12 @@ class UdfCostCatalog(BaseModel):
     _frame_count = Column("frame_count", Integer())
     _resolution = Column("resolution", Integer())
 
-    # TODO: Add hardware information - GPU information etc. - It can be its own table.
-    # TODO: Add relation to UdfCatalog table as one of below:
-    # _name = relationship("UdfCatlog", back_populates="_name")
-    # _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
+    """ 
+    TODO: Add hardware information - GPU information etc. - It can be its own table.
+    TODO: Add relation to UdfCatalog table as one of below:
+    _name = relationship("UdfCatlog", back_populates="_name")
+    _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
+    """
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -41,7 +41,7 @@ class UdfCostCatalog(BaseModel):
     # TODO: Add hardware information - GPU information etc. - It can be its own table.
 
     # _name = relationship("UdfCatlog", back_populates="_name")
-    _name = Column("name", Integer, ForeignKey("udf_catalog.name"))
+    _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -15,10 +15,9 @@
 from dataclasses import dataclass
 
 from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
 
 from eva.catalog.models.base_model import BaseModel
-
-# from sqlalchemy.orm import relationship
 
 
 class UdfCostCatalog(BaseModel):
@@ -41,9 +40,10 @@ class UdfCostCatalog(BaseModel):
     """
     TODO: Add hardware information - GPU information etc. - It can be its own table.
     TODO: Add relation to UdfCatalog table as one of below:
-    _name = relationship("UdfCatlog", back_populates="_name")
     _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
     """
+
+    _name = relationship("UdfCatlog", back_populates="_name")
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -12,54 +12,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass, field
-from typing import List
+from dataclasses import dataclass
 
-from sqlalchemy import Column, String, Integer
-from sqlalchemy.orm import relationship
+from sqlalchemy import Column, Integer, String
 
 from eva.catalog.models.base_model import BaseModel
+
+# from sqlalchemy.orm import relationship
 
 
 class UdfCostCatalog(BaseModel):
     """The `UdfCostCatalog` catalog stores information about the runtime of user-defined functions (UDFs)
-    in the system. It maintains the following information for each UDF. 
-    TODO: add params 
-    
+    in the system. It maintains the following information for each UDF.
+    TODO: add params
+
     """
 
     __tablename__ = "udf_cost_catalog"
-    
+
     _type = Column("type", String(100))
     _cost = Column("cost", Integer())
-    _frame_count  = Column("frame_count", Integer())
+    _frame_count = Column("frame_count", Integer())
     _resolution = Column("resolution", Integer())
-    
-    # TODO: Add hardware information - GPU information etc. - It can be its own table. 
-    
-    # UdfCatalog storing the input/output attributes of the udf
+
+    # TODO: Add hardware information - GPU information etc. - It can be its own table.
+
+    # TODO: UdfCatalog storing the input/output attributes of the udf
     # _name = relationship(
     #     "UdfCatlog", back_populates="_name", cascade="all, delete, delete-orphan"
     # )
 
     _name = Column("name", String(100))
 
-    def __init__(self, name: str, type: str, cost: int, frame_count: int, resolution: int):
+    def __init__(
+        self, name: str, type: str, cost: int, frame_count: int, resolution: int
+    ):
         self._name = name
-        self._type = type 
-        self._cost = cost 
+        self._type = type
+        self._cost = cost
         self._frame_count = frame_count
         self._resolution = resolution
 
     def as_dataclass(self) -> "UdfCostCatalogEntry":
-        args = []
-        outputs = []
         return UdfCostCatalog(
             name=self._name,
             type=self._type,
-            cost=self._cost, 
+            cost=self._cost,
             frame_count=self._frame_count,
-            resolution=self._resolution
+            resolution=self._resolution,
         )
 
 
@@ -72,11 +72,11 @@ class UdfCostCatalogEntry:
     name: str
     impl_file_path: str
     type: str
-    row_id: int 
+    row_id: int
     thorughput_cost: int = None
 
     def display_format(self):
-        # TODO: figure out what needs to be returned in the display format 
+        # TODO: figure out what needs to be returned in the display format
         data_type = self.type.name
 
         return {"name": self.name, "data_type": data_type}

--- a/eva/catalog/models/udf_cost_catalog.py
+++ b/eva/catalog/models/udf_cost_catalog.py
@@ -43,7 +43,7 @@ class UdfCostCatalog(BaseModel):
     _name = Column("name", Integer, ForeignKey("udf_catalog._name"))
     """
 
-    _name = relationship("UdfCatlog", back_populates="_name")
+    _name3 = relationship("UdfCatlog", back_populates="_name2")
 
     def __init__(
         self, name: str, type: str, cost: int, frame_count: int, resolution: int

--- a/eva/catalog/services/udf_cost_catalog_service.py
+++ b/eva/catalog/services/udf_cost_catalog_service.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2018-2022 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+
+from sqlalchemy.orm.exc import NoResultFound
+
+from eva.catalog.models.udf_cost_catalog import UdfCostCatalog
+from eva.catalog.models.udf_cost_catalog import UdfCostCatalogEntry
+from eva.catalog.services.base_service import BaseService
+from eva.utils.logging_manager import logger
+
+
+class UdfCostCatalogService(BaseService):
+    def __init__(self):
+        super().__init__(UdfCostCatalog)
+
+    def insert_entry(self, name: str, type: str, cost: int, frame_count: int, resolution: int) -> UdfCostCatalogEntry:
+        """Insert a new udf cost entry
+
+        Arguments:
+            name (str): name of the udf
+            type(str): type of the udf 
+            cost(int) : cost of the 
+            frame_count = number of frames used in the cost estimation 
+            resolution = resolution of the videos used in the cost estimation
+            
+        Returns:
+            UdfCostCatalogEntry: Returns the new entry created
+        """
+        udf_obj = self.model(name, type, cost, frame_count, resolution)
+        udf_obj = udf_obj.save()
+        return udf_obj.as_dataclass()
+
+    def get_entry_by_name(self, name: str) -> UdfCostCatalogEntry:
+        """return the udf cost entry that matches the name provided.
+           None if no such entry found.
+
+        Arguments:
+            name (str): name to be searched
+        """
+
+        try:
+            udf_obj = self.model.query.filter(self.model._name == name).one()
+            if udf_obj:
+                return udf_obj.as_dataclass()
+            return udf_obj
+        except NoResultFound:
+            return None
+
+   
+    def get_all_entries(self) -> List[UdfCostCatalogEntry]:
+        try:
+            objs = self.model.query.all()
+            return [obj.as_dataclass() for obj in objs]
+        except NoResultFound:
+            return []

--- a/eva/catalog/services/udf_cost_catalog_service.py
+++ b/eva/catalog/services/udf_cost_catalog_service.py
@@ -16,26 +16,26 @@ from typing import List
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from eva.catalog.models.udf_cost_catalog import UdfCostCatalog
-from eva.catalog.models.udf_cost_catalog import UdfCostCatalogEntry
+from eva.catalog.models.udf_cost_catalog import UdfCostCatalog, UdfCostCatalogEntry
 from eva.catalog.services.base_service import BaseService
-from eva.utils.logging_manager import logger
 
 
 class UdfCostCatalogService(BaseService):
     def __init__(self):
         super().__init__(UdfCostCatalog)
 
-    def insert_entry(self, name: str, type: str, cost: int, frame_count: int, resolution: int) -> UdfCostCatalogEntry:
+    def insert_entry(
+        self, name: str, type: str, cost: int, frame_count: int, resolution: int
+    ) -> UdfCostCatalogEntry:
         """Insert a new udf cost entry
 
         Arguments:
             name (str): name of the udf
-            type(str): type of the udf 
-            cost(int) : cost of the 
-            frame_count = number of frames used in the cost estimation 
+            type(str): type of the udf
+            cost(int) : cost of the
+            frame_count = number of frames used in the cost estimation
             resolution = resolution of the videos used in the cost estimation
-            
+
         Returns:
             UdfCostCatalogEntry: Returns the new entry created
         """
@@ -59,7 +59,6 @@ class UdfCostCatalogService(BaseService):
         except NoResultFound:
             return None
 
-   
     def get_all_entries(self) -> List[UdfCostCatalogEntry]:
         try:
             objs = self.model.query.all()

--- a/eva/executor/function_scan_executor.py
+++ b/eva/executor/function_scan_executor.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 from typing import Iterator
 
+from eva.catalog.catalog_manager import CatalogManager
 from eva.executor.abstract_executor import AbstractExecutor
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.function_scan_plan import FunctionScanPlan
 from eva.utils.logging_manager import logger
-
+from time import time
 
 class FunctionScanExecutor(AbstractExecutor):
     """
@@ -37,14 +38,33 @@ class FunctionScanExecutor(AbstractExecutor):
     def validate(self):
         pass
 
+    def persistCost(self, name, type, frame_count, resolution, time):
+        # TODO: compute cost using time
+        cost = time
+        catalog_manager = CatalogManager()
+        catalog_manager.insert_udf_cost_catalog_entry(name, type, cost, frame_count, resolution)
+
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
         assert (
             "lateral_input" in kwargs
         ), "Key lateral_input not passed to the FunctionScan"
         lateral_input = kwargs.get("lateral_input")
+        catalog_manager = CatalogManager()
         try:
             if not lateral_input.empty():
+                t_start = time()
                 res = self.func_expr.evaluate(lateral_input)
+                t_end = time()
+                time_taken =  t_end - t_start
+                resolution = None
+                udf_obj = catalog_manager.get_udf_catalog_entry_by_name(
+                    self.func_expr.name
+                )
+                if(udf_obj):
+                    type = udf_obj.type
+                else:
+                    type = None
+                self.persistCost(self.func_expr.name, type, lateral_input.frames.shape[0], resolution, time_taken)
                 if not res.empty():
                     if self.do_unnest:
                         res.unnest()

--- a/eva/executor/function_scan_executor.py
+++ b/eva/executor/function_scan_executor.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from time import time
 from typing import Iterator
 
 from eva.catalog.catalog_manager import CatalogManager
@@ -20,7 +21,7 @@ from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.function_scan_plan import FunctionScanPlan
 from eva.utils.logging_manager import logger
-from time import time
+
 
 class FunctionScanExecutor(AbstractExecutor):
     """
@@ -42,7 +43,9 @@ class FunctionScanExecutor(AbstractExecutor):
         # TODO: compute cost using time
         cost = time
         catalog_manager = CatalogManager()
-        catalog_manager.insert_udf_cost_catalog_entry(name, type, cost, frame_count, resolution)
+        catalog_manager.insert_udf_cost_catalog_entry(
+            name, type, cost, frame_count, resolution
+        )
 
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
         assert (
@@ -55,16 +58,22 @@ class FunctionScanExecutor(AbstractExecutor):
                 t_start = time()
                 res = self.func_expr.evaluate(lateral_input)
                 t_end = time()
-                time_taken =  t_end - t_start
+                time_taken = t_end - t_start
                 resolution = None
                 udf_obj = catalog_manager.get_udf_catalog_entry_by_name(
                     self.func_expr.name
                 )
-                if(udf_obj):
+                if udf_obj:
                     type = udf_obj.type
                 else:
                     type = None
-                self.persistCost(self.func_expr.name, type, lateral_input.frames.shape[0], resolution, time_taken)
+                self.persistCost(
+                    self.func_expr.name,
+                    type,
+                    lateral_input.frames.shape[0],
+                    resolution,
+                    time_taken,
+                )
                 if not res.empty():
                     if self.do_unnest:
                         res.unnest()

--- a/test/catalog/services/test_udf_cost_catalog_service.py
+++ b/test/catalog/services/test_udf_cost_catalog_service.py
@@ -22,7 +22,7 @@ from eva.catalog.services.udf_cost_catalog_service import UdfCostCatalogService
 UDF_TYPE = "classification"
 UDF_NAME = "name"
 UDF_COST = 1
-FRAME_COUNT = 1 
+FRAME_COUNT = 1
 RESOLUTION = 1
 
 

--- a/test/catalog/services/test_udf_cost_catalog_service.py
+++ b/test/catalog/services/test_udf_cost_catalog_service.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+# Copyright 2018-2022 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import TestCase
+
+from mock import patch
+from sqlalchemy.orm.exc import NoResultFound
+
+from eva.catalog.services.udf_cost_catalog_service import UdfCostCatalogService
+
+UDF_TYPE = "classification"
+UDF_NAME = "name"
+UDF_COST = 1
+FRAME_COUNT = 1 
+RESOLUTION = 1
+
+
+class UdfCostCatalogServiceTest(TestCase):
+    @patch("eva.catalog.services.udf_cost_catalog_service.UdfCostCatalog")
+    def test_create_udf_should_create_model(self, mocked):
+        service = UdfCostCatalogService()
+        service.insert_entry(UDF_NAME, UDF_TYPE, UDF_COST, FRAME_COUNT, RESOLUTION)
+        mocked.assert_called_with(UDF_NAME, UDF_TYPE, UDF_COST, FRAME_COUNT, RESOLUTION)
+        mocked.return_value.save.assert_called_once()
+
+    @patch("eva.catalog.services.udf_cost_catalog_service.UdfCostCatalog")
+    def test_udf_by_name_should_query_model_with_name(self, mocked):
+        service = UdfCostCatalogService()
+        expected = mocked.query.filter.return_value.one.return_value
+
+        actual = service.get_entry_by_name(UDF_NAME)
+        mocked.query.filter.assert_called_with(mocked._name == UDF_NAME)
+        mocked.query.filter.return_value.one.assert_called_once()
+        self.assertEqual(actual, expected.as_dataclass.return_value)
+
+    @patch("eva.catalog.services.udf_catalog_service.UdfCatalog")
+    def test_get_all_udfs_should_return_empty(self, mocked):
+        service = UdfCostCatalogService()
+        mocked.query.all.side_effect = Exception(NoResultFound)
+        with self.assertRaises(Exception):
+            self.assertEqual(service.get_all_entries(), [])

--- a/test/catalog/services/test_udf_cost_catalog_service.py
+++ b/test/catalog/services/test_udf_cost_catalog_service.py
@@ -44,7 +44,7 @@ class UdfCostCatalogServiceTest(TestCase):
         mocked.query.filter.return_value.one.assert_called_once()
         self.assertEqual(actual, expected.as_dataclass.return_value)
 
-    @patch("eva.catalog.services.udf_catalog_service.UdfCatalog")
+    @patch("eva.catalog.services.udf_cost_catalog_service.UdfCostCatalog")
     def test_get_all_udfs_should_return_empty(self, mocked):
         service = UdfCostCatalogService()
         mocked.query.all.side_effect = Exception(NoResultFound)


### PR DESCRIPTION
This PR adds a UDF cost catalog table that can be used to store the function expression execution time as a cost. In the future, more complex functions can be used to cost UDFs.