### PR TITLE
fix: insert and delete executor

### DIFF
--- a/eva/executor/delete_executor.py
+++ b/eva/executor/delete_executor.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Generator, Iterator
+from typing import Iterator
 
 import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.catalog.catalog_type import TableType
 from eva.executor.abstract_executor import AbstractExecutor
-from eva.executor.executor_utils import ExecutorError, apply_predicate
+from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.project_plan import ProjectPlan
 from eva.storage.storage_engine import StorageEngine

--- a/eva/executor/delete_executor.py
+++ b/eva/executor/delete_executor.py
@@ -42,40 +42,15 @@ class DeleteExecutor(AbstractExecutor):
             table_catalog = self.node.table_ref.table.table_obj
             storage_engine = StorageEngine.factory(table_catalog)
 
-            del_batch = Batch()
-
             if table_catalog.table_type == TableType.VIDEO_DATA:
                 raise NotImplementedError("DELETE only implemented for structured data")
+                # storage_engine.delete(table_catalog, del_batch)
             elif table_catalog.table_type == TableType.IMAGE_DATA:
                 raise NotImplementedError("DELETE only implemented for structured data")
+                # storage_engine.delete(table_catalog, del_batch)
             elif table_catalog.table_type == TableType.STRUCTURED_DATA:
-                del_batch = storage_engine.read(table_catalog)
-                del_batch = list(del_batch)[0]
+                storage_engine.delete(table_catalog, self.predicate)
 
-            # Added because of inconsistency in col_alias in Structured data Batch project function
-            original_column_names = list(del_batch.frames.columns)
-            column_names = [
-                f"{table_catalog.name.lower()}.{name}"
-                for name in original_column_names
-                if not name == "_row_id"
-            ]
-            column_names.insert(0, "_row_id")
-            del_batch.frames.columns = column_names
-            del_batch = apply_predicate(del_batch, self.predicate)
-
-            # All the batches that need to be deleted
-
-            if table_catalog.table_type == TableType.VIDEO_DATA:
-                storage_engine.delete(table_catalog, del_batch)
-            elif table_catalog.table_type == TableType.IMAGE_DATA:
-                storage_engine.delete(table_catalog, del_batch)
-            elif table_catalog.table_type == TableType.STRUCTURED_DATA:
-                del_batch.frames.columns = original_column_names
-                table_needed = del_batch.frames[
-                    [f"{self.predicate.children[0].col_name}"]
-                ]
-                for num in range(len(del_batch)):
-                    storage_engine.delete(table_catalog, table_needed.iloc[num])
             yield Batch(pd.DataFrame(["Deleted rows"]))
 
         except Exception as e:

--- a/eva/executor/delete_executor.py
+++ b/eva/executor/delete_executor.py
@@ -76,11 +76,8 @@ class DeleteExecutor(AbstractExecutor):
                 ]
                 for num in range(len(del_batch)):
                     storage_engine.delete(table_catalog, table_needed.iloc[num])
-            yield Batch(pd.DataFrame(["Deleted row"]))
+            yield Batch(pd.DataFrame(["Deleted rows"]))
 
         except Exception as e:
             logger.error(e)
             raise ExecutorError(e)
-
-    def __call__(self, **kwargs) -> Generator[Batch, None, None]:
-        yield from self.exec(**kwargs)

--- a/eva/executor/insert_executor.py
+++ b/eva/executor/insert_executor.py
@@ -49,13 +49,9 @@ class InsertExecutor(AbstractExecutor):
             if table_catalog_entry.table_type != TableType.STRUCTURED_DATA:
                 raise NotImplementedError("INSERT only implemented for structured data")
 
-            values_to_insert = []
-            for i in self.node.value_list:
-                values_to_insert.append(i.value)
+            values_to_insert = [value.value for value in self.node.value_list]
             tuple_to_insert = tuple(values_to_insert)
-            columns_to_insert = []
-            for i in self.node.column_list:
-                columns_to_insert.append(i.col_name)
+            columns_to_insert = [value.col_name for value in self.node.column_list]
 
             # Adding all values to Batch for insert
             logger.info(values_to_insert)
@@ -72,18 +68,4 @@ class InsertExecutor(AbstractExecutor):
         else:
             yield Batch(
                 pd.DataFrame([f"Number of rows loaded: {str(len(values_to_insert))}"])
-            )
-
-    def _rollback_load(
-        self,
-        storage_engine: AbstractStorageEngine,
-        table_obj: TableCatalogEntry,
-        do_create: bool,
-    ):
-        try:
-            if do_create:
-                storage_engine.drop(table_obj)
-        except Exception as e:
-            logger.exception(
-                f"Unexpected Exception {e} occured while rolling back. This is bad as the {self.media_type.name} table can be in a corrupt state. Please verify the table {table_obj} for correctness."
             )

--- a/eva/executor/insert_executor.py
+++ b/eva/executor/insert_executor.py
@@ -16,12 +16,10 @@ import pandas as pd
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.catalog.catalog_type import TableType
-from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.executor.abstract_executor import AbstractExecutor
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.insert_plan import InsertPlan
-from eva.storage.abstract_storage_engine import AbstractStorageEngine
 from eva.storage.storage_engine import StorageEngine
 from eva.utils.logging_manager import logger
 
@@ -51,7 +49,9 @@ class InsertExecutor(AbstractExecutor):
 
             values_to_insert = [val_node.value for val_node in self.node.value_list]
             tuple_to_insert = tuple(values_to_insert)
-            columns_to_insert = [col_node.col_name for col_node in self.node.column_list]
+            columns_to_insert = [
+                col_node.col_name for col_node in self.node.column_list
+            ]
 
             # Adding all values to Batch for insert
             logger.info(values_to_insert)

--- a/eva/executor/insert_executor.py
+++ b/eva/executor/insert_executor.py
@@ -49,9 +49,9 @@ class InsertExecutor(AbstractExecutor):
             if table_catalog_entry.table_type != TableType.STRUCTURED_DATA:
                 raise NotImplementedError("INSERT only implemented for structured data")
 
-            values_to_insert = [value.value for value in self.node.value_list]
+            values_to_insert = [val_node.value for val_node in self.node.value_list]
             tuple_to_insert = tuple(values_to_insert)
-            columns_to_insert = [value.col_name for value in self.node.column_list]
+            columns_to_insert = [col_node.col_name for col_node in self.node.column_list]
 
             # Adding all values to Batch for insert
             logger.info(values_to_insert)

--- a/eva/expression/expression_utils.py
+++ b/eva/expression/expression_utils.py
@@ -21,6 +21,8 @@ from eva.expression.constant_value_expression import ConstantValueExpression
 from eva.expression.logical_expression import LogicalExpression
 from eva.expression.tuple_value_expression import TupleValueExpression
 
+from eva.catalog.models.table_catalog import TableCatalogEntry
+
 
 def to_conjunction_list(
     expression_tree: AbstractExpression,
@@ -297,3 +299,26 @@ def is_simple_predicate(predicate: AbstractExpression) -> bool:
     ]
 
     return _has_simple_expressions(predicate) and contains_single_column(predicate)
+
+
+def predicate_node_to_filter(
+        self, table: TableCatalogEntry, predicate_node: ComparisonExpression
+    ):
+        filter_clause = []
+        column = predicate_node.children[0].col_name
+        value = predicate_node.children[1].value
+
+        if predicate_node.etype == ExpressionType.COMPARE_EQUAL:
+            filter_clause.append(table.columns[column] == value)
+        elif predicate_node.etype == ExpressionType.COMPARE_GREATER:
+            filter_clause.append(table.columns[column] > value)
+        elif predicate_node.etype == ExpressionType.COMPARE_LESSER:
+            filter_clause.append(table.columns[column] < value)
+        elif predicate_node.etype == ExpressionType.COMPARE_GEQ:
+            filter_clause.append(table.columns[column] >= value)
+        elif predicate_node.etype == ExpressionType.COMPARE_LEQ:
+            filter_clause.append(table.columns[column] <= value)
+        elif predicate_node.etype == ExpressionType.COMPARE_NEQ:
+            filter_clause.append(table.columns[column] != value)
+
+        return filter_clause

--- a/eva/expression/expression_utils.py
+++ b/eva/expression/expression_utils.py
@@ -15,13 +15,12 @@
 
 from typing import List, Set
 
+from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.expression.abstract_expression import AbstractExpression, ExpressionType
 from eva.expression.comparison_expression import ComparisonExpression
 from eva.expression.constant_value_expression import ConstantValueExpression
 from eva.expression.logical_expression import LogicalExpression
 from eva.expression.tuple_value_expression import TupleValueExpression
-
-from eva.catalog.models.table_catalog import TableCatalogEntry
 
 
 def to_conjunction_list(
@@ -302,23 +301,23 @@ def is_simple_predicate(predicate: AbstractExpression) -> bool:
 
 
 def predicate_node_to_filter(
-        self, table: TableCatalogEntry, predicate_node: ComparisonExpression
-    ):
-        filter_clause = []
-        column = predicate_node.children[0].col_name
-        value = predicate_node.children[1].value
+    self, table: TableCatalogEntry, predicate_node: ComparisonExpression
+):
+    filter_clause = []
+    column = predicate_node.children[0].col_name
+    value = predicate_node.children[1].value
 
-        if predicate_node.etype == ExpressionType.COMPARE_EQUAL:
-            filter_clause.append(table.columns[column] == value)
-        elif predicate_node.etype == ExpressionType.COMPARE_GREATER:
-            filter_clause.append(table.columns[column] > value)
-        elif predicate_node.etype == ExpressionType.COMPARE_LESSER:
-            filter_clause.append(table.columns[column] < value)
-        elif predicate_node.etype == ExpressionType.COMPARE_GEQ:
-            filter_clause.append(table.columns[column] >= value)
-        elif predicate_node.etype == ExpressionType.COMPARE_LEQ:
-            filter_clause.append(table.columns[column] <= value)
-        elif predicate_node.etype == ExpressionType.COMPARE_NEQ:
-            filter_clause.append(table.columns[column] != value)
+    if predicate_node.etype == ExpressionType.COMPARE_EQUAL:
+        filter_clause.append(table.columns[column] == value)
+    elif predicate_node.etype == ExpressionType.COMPARE_GREATER:
+        filter_clause.append(table.columns[column] > value)
+    elif predicate_node.etype == ExpressionType.COMPARE_LESSER:
+        filter_clause.append(table.columns[column] < value)
+    elif predicate_node.etype == ExpressionType.COMPARE_GEQ:
+        filter_clause.append(table.columns[column] >= value)
+    elif predicate_node.etype == ExpressionType.COMPARE_LEQ:
+        filter_clause.append(table.columns[column] <= value)
+    elif predicate_node.etype == ExpressionType.COMPARE_NEQ:
+        filter_clause.append(table.columns[column] != value)
 
-        return filter_clause
+    return filter_clause

--- a/eva/storage/sqlite_storage_engine.py
+++ b/eva/storage/sqlite_storage_engine.py
@@ -187,8 +187,6 @@ class SQLStorageEngine(AbstractStorageEngine):
             logger.exception(err_msg)
             raise Exception(err_msg)
 
-    
-
     def delete(self, table: TableCatalogEntry, where_clause: ComparisonExpression):
         """Delete tuples from the table where rows satisfy the where_clause.
         The current implementation only handles equality predicates.

--- a/eva/storage/sqlite_storage_engine.py
+++ b/eva/storage/sqlite_storage_engine.py
@@ -26,6 +26,7 @@ from eva.catalog.schema_utils import SchemaUtils
 from eva.catalog.sql_config import IDENTIFIER_COLUMN, SQLConfig
 from eva.expression.abstract_expression import ExpressionType
 from eva.expression.comparison_expression import ComparisonExpression
+from eva.expression.expression_utils import predicate_node_to_filter
 from eva.models.storage.batch import Batch
 from eva.parser.table_ref import TableInfo
 from eva.storage.abstract_storage_engine import AbstractStorageEngine
@@ -186,27 +187,7 @@ class SQLStorageEngine(AbstractStorageEngine):
             logger.exception(err_msg)
             raise Exception(err_msg)
 
-    def single_predicate_node_to_filter(
-        self, table: TableCatalogEntry, predicate_node: ComparisonExpression
-    ):
-        filter_clause = []
-        column = predicate_node.children[0].col_name
-        value = predicate_node.children[1].value
-
-        if predicate_node.etype == ExpressionType.COMPARE_EQUAL:
-            filter_clause.append(table.columns[column] == value)
-        elif predicate_node.etype == ExpressionType.COMPARE_GREATER:
-            filter_clause.append(table.columns[column] > value)
-        elif predicate_node.etype == ExpressionType.COMPARE_LESSER:
-            filter_clause.append(table.columns[column] < value)
-        elif predicate_node.etype == ExpressionType.COMPARE_GEQ:
-            filter_clause.append(table.columns[column] >= value)
-        elif predicate_node.etype == ExpressionType.COMPARE_LEQ:
-            filter_clause.append(table.columns[column] <= value)
-        elif predicate_node.etype == ExpressionType.COMPARE_NEQ:
-            filter_clause.append(table.columns[column] != value)
-
-        return filter_clause
+    
 
     def delete(self, table: TableCatalogEntry, where_clause: ComparisonExpression):
         """Delete tuples from the table where rows satisfy the where_clause.

--- a/eva/storage/sqlite_storage_engine.py
+++ b/eva/storage/sqlite_storage_engine.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Iterator, List
+from typing import Iterator, List
 
 import numpy as np
 import pandas as pd
@@ -24,13 +24,13 @@ from eva.catalog.models.column_catalog import ColumnCatalogEntry
 from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.catalog.schema_utils import SchemaUtils
 from eva.catalog.sql_config import IDENTIFIER_COLUMN, SQLConfig
+from eva.expression.abstract_expression import ExpressionType
+from eva.expression.comparison_expression import ComparisonExpression
 from eva.models.storage.batch import Batch
 from eva.parser.table_ref import TableInfo
 from eva.storage.abstract_storage_engine import AbstractStorageEngine
 from eva.utils.generic_utils import PickleSerializer, get_size
 from eva.utils.logging_manager import logger
-from eva.expression.comparison_expression import ComparisonExpression
-from eva.expression.abstract_expression import ExpressionType
 
 # Leveraging Dynamic schema in SQLAlchemy
 # https://sparrigan.github.io/sql/sqla/2016/01/03/dynamic-tables.html
@@ -186,24 +186,26 @@ class SQLStorageEngine(AbstractStorageEngine):
             logger.exception(err_msg)
             raise Exception(err_msg)
 
-    def single_predicate_node_to_filter(self, table: TableCatalogEntry, predicate_node: ComparisonExpression):
+    def single_predicate_node_to_filter(
+        self, table: TableCatalogEntry, predicate_node: ComparisonExpression
+    ):
         filter_clause = []
         column = predicate_node.children[0].col_name
         value = predicate_node.children[1].value
-        
-        if (predicate_node.etype == ExpressionType.COMPARE_EQUAL):
+
+        if predicate_node.etype == ExpressionType.COMPARE_EQUAL:
             filter_clause.append(table.columns[column] == value)
-        elif (predicate_node.etype == ExpressionType.COMPARE_GREATER):
+        elif predicate_node.etype == ExpressionType.COMPARE_GREATER:
             filter_clause.append(table.columns[column] > value)
-        elif (predicate_node.etype == ExpressionType.COMPARE_LESSER):
+        elif predicate_node.etype == ExpressionType.COMPARE_LESSER:
             filter_clause.append(table.columns[column] < value)
-        elif (predicate_node.etype == ExpressionType.COMPARE_GEQ):
+        elif predicate_node.etype == ExpressionType.COMPARE_GEQ:
             filter_clause.append(table.columns[column] >= value)
-        elif (predicate_node.etype == ExpressionType.COMPARE_LEQ):
+        elif predicate_node.etype == ExpressionType.COMPARE_LEQ:
             filter_clause.append(table.columns[column] <= value)
-        elif (predicate_node.etype == ExpressionType.COMPARE_NEQ):
+        elif predicate_node.etype == ExpressionType.COMPARE_NEQ:
             filter_clause.append(table.columns[column] != value)
-        
+
         return filter_clause
 
     def delete(self, table: TableCatalogEntry, where_clause: ComparisonExpression):
@@ -218,11 +220,10 @@ class SQLStorageEngine(AbstractStorageEngine):
         """
         try:
             table_to_delete_from = self._try_loading_table_via_reflection(table.name)
-            
+
             filter_clause = self.single_predicate_node_to_filter(
-                table=table_to_delete_from,
-                predicate_node=where_clause
-                )
+                table=table_to_delete_from, predicate_node=where_clause
+            )
             # verify where clause and convert to sqlalchemy supported filter
             # https://stackoverflow.com/questions/34026210/where-filter-from-table-object-using-a-dictionary-or-kwargs
 

--- a/test/integration_tests/test_insert_executor.py
+++ b/test/integration_tests/test_insert_executor.py
@@ -47,12 +47,12 @@ class InsertExecutorTest(unittest.TestCase):
         query = """LOAD VIDEO 'dummy.avi' INTO MyVideo;"""
         execute_query_fetch_all(query)
 
-        insert_query = """ INSERT INTO MyVideo (id, data) VALUES 
+        insert_query = """ INSERT INTO MyVideo (id, data) VALUES
             (40, [[40, 40, 40], [40, 40, 40]],
                  [[40, 40, 40], [40, 40, 40]]);"""
         execute_query_fetch_all(insert_query)
 
-        insert_query_2 = """ INSERT INTO MyVideo (id, data) VALUES 
+        insert_query_2 = """ INSERT INTO MyVideo (id, data) VALUES
         ( 41, [[41, 41, 41] , [41, 41, 41]],
                 [[41, 41, 41], [41, 41, 41]]);"""
         execute_query_fetch_all(insert_query_2)

--- a/test/integration_tests/test_insert_executor.py
+++ b/test/integration_tests/test_insert_executor.py
@@ -47,28 +47,14 @@ class InsertExecutorTest(unittest.TestCase):
         query = """LOAD VIDEO 'dummy.avi' INTO MyVideo;"""
         execute_query_fetch_all(query)
 
-        insert_query = """ INSERT INTO MyVideo (id, data) VALUES (
-            [
-                [
-                    40,
-                    [
-                        [[40, 40, 40], [40, 40, 40]],
-                        [[40, 40, 40], [40, 40, 40]]
-                    ]
-                ]
-            ]);"""
+        insert_query = """ INSERT INTO MyVideo (id, data) VALUES 
+            (40, [[40, 40, 40], [40, 40, 40]],
+                 [[40, 40, 40], [40, 40, 40]]);"""
         execute_query_fetch_all(insert_query)
 
-        insert_query_2 = """ INSERT INTO MyVideo (id, data) VALUES (
-            [
-                [
-                    41,
-                    [
-                        [[41, 41, 41] , [41, 41, 41]],
-                        [[41, 41, 41], [41, 41, 41]]
-                    ]
-                ]
-            ]);"""
+        insert_query_2 = """ INSERT INTO MyVideo (id, data) VALUES 
+        ( 41, [[41, 41, 41] , [41, 41, 41]],
+                [[41, 41, 41], [41, 41, 41]]);"""
         execute_query_fetch_all(insert_query_2)
 
         query = "SELECT id, data FROM MyVideo WHERE id = 40"


### PR DESCRIPTION
Fixing issues in insert and delete executor based on feedback from @gaurav274 

- [x] Using list comprehension in `insert_executor`.
- [x] Removing `_roll_back` from the executors.
- [x] Using descriptive variable names.
- [x] Applying predicate function in `delete_executor` using the SQLAlchemy.
- [x] Move `single_predicate_to_filter()` to ExpressionUtils.
- [ ] Make it more robust (take into consideration `AND` and `OR`)
- [ ] Adding test cases for `single_predicate()`.