### PR TITLE
feat: allow UDF's to be created with any name (irrespective of class name) 

### DIFF
--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -228,7 +228,9 @@ class StatementBinder:
             raise BinderError(err_msg)
 
         try:
-            node.function = load_udf_class_from_file(udf_obj.impl_file_path, udf_obj.name)
+            node.function = load_udf_class_from_file(
+                udf_obj.impl_file_path, udf_obj.name
+            )
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the UDF class name in the"

--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -36,7 +36,7 @@ from eva.parser.rename_statement import RenameTableStatement
 from eva.parser.select_statement import SelectStatement
 from eva.parser.statement import AbstractStatement
 from eva.parser.table_ref import TableRef
-from eva.utils.generic_utils import path_to_class
+from eva.utils.generic_utils import load_udf_class_from_file
 from eva.utils.logging_manager import logger
 
 if sys.version_info >= (3, 8):
@@ -228,7 +228,7 @@ class StatementBinder:
             raise BinderError(err_msg)
 
         try:
-            node.function = path_to_class(udf_obj.impl_file_path, udf_obj.name)
+            node.function = load_udf_class_from_file(udf_obj.impl_file_path, udf_obj.name)
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the UDF class name in the"

--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -228,7 +228,7 @@ class StatementBinder:
             raise BinderError(err_msg)
 
         try:
-            node.function = load_udf_class_from_file(udf_obj.impl_file_path)
+            node.function = load_udf_class_from_file(udf_obj.impl_file_path, udf_obj.name)
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the UDF class name in the"

--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -229,7 +229,7 @@ class StatementBinder:
 
         try:
             node.function = load_udf_class_from_file(
-                udf_obj.impl_file_path, udf_obj.name
+                udf_obj.impl_file_path
             )
         except Exception as e:
             err_msg = (

--- a/eva/binder/statement_binder.py
+++ b/eva/binder/statement_binder.py
@@ -228,9 +228,7 @@ class StatementBinder:
             raise BinderError(err_msg)
 
         try:
-            node.function = load_udf_class_from_file(
-                udf_obj.impl_file_path
-            )
+            node.function = load_udf_class_from_file(udf_obj.impl_file_path)
         except Exception as e:
             err_msg = (
                 f"{str(e)}. Please verify that the UDF class name in the"

--- a/eva/executor/create_udf_executor.py
+++ b/eva/executor/create_udf_executor.py
@@ -52,7 +52,7 @@ class CreateUDFExecutor(AbstractExecutor):
         impl_path = self.node.impl_path.absolute().as_posix()
         # check if we can create the udf object
         try:
-            load_udf_class_from_file(impl_path)()
+            load_udf_class_from_file(impl_path, self.node.name)()
         except Exception as e:
             err_msg = f"Error creating UDF: {str(e)}"
             logger.error(err_msg)

--- a/eva/executor/create_udf_executor.py
+++ b/eva/executor/create_udf_executor.py
@@ -52,7 +52,7 @@ class CreateUDFExecutor(AbstractExecutor):
         impl_path = self.node.impl_path.absolute().as_posix()
         # check if we can create the udf object
         try:
-            load_udf_class_from_file(impl_path, self.node.name)()
+            load_udf_class_from_file(impl_path)()
         except Exception as e:
             err_msg = f"Error creating UDF: {str(e)}"
             logger.error(err_msg)

--- a/eva/executor/create_udf_executor.py
+++ b/eva/executor/create_udf_executor.py
@@ -18,7 +18,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.executor.abstract_executor import AbstractExecutor
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.create_udf_plan import CreateUDFPlan
-from eva.utils.generic_utils import path_to_class
+from eva.utils.generic_utils import load_udf_class_from_file
 from eva.utils.logging_manager import logger
 
 
@@ -52,11 +52,10 @@ class CreateUDFExecutor(AbstractExecutor):
         impl_path = self.node.impl_path.absolute().as_posix()
         # check if we can create the udf object
         try:
-            path_to_class(impl_path, self.node.name)()
+            load_udf_class_from_file(impl_path, self.node.name)()
         except Exception as e:
             err_msg = (
-                f"{str(e)}. Please verify that the UDF class name in the "
-                f"implementation file matches the provided UDF name {self.node.name}."
+                f"Error creating UDF: {str(e)}"
             )
             logger.error(err_msg)
             raise RuntimeError(err_msg)

--- a/eva/executor/create_udf_executor.py
+++ b/eva/executor/create_udf_executor.py
@@ -54,9 +54,7 @@ class CreateUDFExecutor(AbstractExecutor):
         try:
             load_udf_class_from_file(impl_path, self.node.name)()
         except Exception as e:
-            err_msg = (
-                f"Error creating UDF: {str(e)}"
-            )
+            err_msg = f"Error creating UDF: {str(e)}"
             logger.error(err_msg)
             raise RuntimeError(err_msg)
         catalog_manager.insert_udf_catalog_entry(

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -52,7 +52,7 @@ def str_to_class(class_path: str):
 
 def load_udf_class_from_file(filepath, classname=None):
     """
-    Load a class from a Python file.
+    Load a class from a Python file. If the classname is not specified, the function will check if there is only one class in the file and load that. If there are multiple classes, it will raise an error.
 
     Args:
         filepath (str): The path to the Python file.
@@ -62,8 +62,7 @@ def load_udf_class_from_file(filepath, classname=None):
         The class instance.
 
     Raises:
-        ImportError: If the file can't be imported.
-        ValueError: If the class name is not found or there is more than one class in the file.
+        RuntimeError: If the class name is not found or there is more than one class in the file.
     """
     try:
         abs_path = Path(filepath).resolve()

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -88,7 +88,7 @@ def load_udf_class_from_file(filepath, classname=None):
     ]
     if len(classes) != 1:
         raise RuntimeError(
-            f"{filepath} contains {len(classes)} classes, please specify the main class by naming the UDF with the same name."
+            f"{filepath} contains {len(classes)} classes, please specify the correct class to load by naming the UDF with the same name in the CREATE query."
         )
     return classes[0]
 

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -71,7 +71,7 @@ def load_udf_class_from_file(filepath, classname=None):
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
     except Exception as e:
-        err_msg = f"Couldn't load UDF from {filepath}. Ensure that the file exists and that it is a valid Python file."
+        err_msg = f"Couldn't load UDF from {filepath} : {str(e)}. Ensure that the file exists and that it is a valid Python file."
         raise RuntimeError(err_msg)
 
     # Try to load the specified class by name

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import hashlib
 import importlib
+import inspect
 import pickle
 import sys
 import uuid
@@ -49,28 +50,40 @@ def str_to_class(class_path: str):
     return getattr(module, class_name)
 
 
-def path_to_class(filepath: str, classname: str):
+def load_udf_class_from_file(filepath, classname=None):
     """
-    Convert the class in the path file into an object
+    Load a class from a Python file.
 
-    Arguments:
-        filepath: absolute path of file
-        classname: the name of the imported class
+    Args:
+        filepath (str): The path to the Python file.
+        classname (str, optional): The name of the class to load. If not specified, the function will try to load a class with the same name as the file. Defaults to None.
 
     Returns:
-        type: A class for given path
+        The class instance.
+
+    Raises:
+        ImportError: If the file can't be imported.
+        ValueError: If the class name is not found or there is more than one class in the file.
     """
-    try:
-        abs_path = Path(filepath).resolve()
-        spec = importlib.util.spec_from_file_location(abs_path.stem, abs_path)
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        classobj = getattr(module, classname)
-    except Exception as e:
-        err_msg = f"Failed to import {classname} from {filepath}\nException: {str(e)}"
-        logger.error(err_msg)
-        raise RuntimeError(err_msg)
-    return classobj
+    module_name = inspect.getmodulename(filepath)
+    if module_name is None:
+        raise ImportError(f"Couldn't import module from {filepath}")
+    module = importlib.import_module(module_name, filepath)
+
+    # Try to load the specified class by name
+    if classname:
+        if hasattr(module, classname):
+            return getattr(module, classname)
+        else:
+            raise RuntimeError(f"Class {classname} not found in {filepath}")
+
+    # If class name not specified, check if there is only one class in the file
+    classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj)]
+    if len(classes) != 1:
+        raise RuntimeError(
+            f"{filepath} contains multiple classes, please specify the main class by naming the UDF with the same name."
+        )
+    return classes[0]
 
 
 def is_gpu_available() -> bool:

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -72,7 +72,7 @@ def load_udf_class_from_file(filepath, classname=None):
         spec.loader.exec_module(module)
     except Exception as e:
         err_msg = f"Couldn't load UDF from {filepath}. Ensure that the file exists and that it is a valid Python file."
-        raise RuntimeError(err_msg) 
+        raise RuntimeError(err_msg)
 
     # Try to load the specified class by name
     if classname:

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -82,10 +82,14 @@ def load_udf_class_from_file(filepath, classname=None):
             raise RuntimeError(f"Class {classname} not found in {filepath}")
 
     # If class name not specified, check if there is only one class in the file
-    classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj)]
+    classes = [
+        obj
+        for _, obj in inspect.getmembers(module, inspect.isclass)
+        if obj.__module__ == module.__name__
+    ]
     if len(classes) != 1:
         raise RuntimeError(
-            f"{filepath} contains multiple classes, please specify the main class by naming the UDF with the same name."
+            f"{filepath} contains {len(classes)} classes, please specify the main class by naming the UDF with the same name."
         )
     return classes[0]
 

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -74,11 +74,8 @@ def load_udf_class_from_file(filepath, classname=None):
         raise RuntimeError(err_msg)
 
     # Try to load the specified class by name
-    if classname:
-        if hasattr(module, classname):
-            return getattr(module, classname)
-        else:
-            raise RuntimeError(f"Class {classname} not found in {filepath}")
+    if classname and hasattr(module, classname):
+        return getattr(module, classname)
 
     # If class name not specified, check if there is only one class in the file
     classes = [

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -65,10 +65,14 @@ def load_udf_class_from_file(filepath, classname=None):
         ImportError: If the file can't be imported.
         ValueError: If the class name is not found or there is more than one class in the file.
     """
-    module_name = inspect.getmodulename(filepath)
-    if module_name is None:
-        raise ImportError(f"Couldn't import module from {filepath}")
-    module = importlib.import_module(module_name, filepath)
+    try:
+        abs_path = Path(filepath).resolve()
+        spec = importlib.util.spec_from_file_location(abs_path.stem, abs_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception as e:
+        err_msg = f"Couldn't load UDF from {filepath}. Ensure that the file exists and that it is a valid Python file."
+        raise RuntimeError(err_msg) 
 
     # Try to load the specified class by name
     if classname:

--- a/test/binder/test_statement_binder.py
+++ b/test/binder/test_statement_binder.py
@@ -142,7 +142,9 @@ class StatementBinderTests(unittest.TestCase):
             mock_catalog().get_udf_io_catalog_output_entries
         ) = MagicMock()
         mock_get_udf_outputs.return_value = func_ouput_objs
-        mock_load_udf_class_from_file.return_value.return_value = "load_udf_class_from_file"
+        mock_load_udf_class_from_file.return_value.return_value = (
+            "load_udf_class_from_file"
+        )
 
         # Case 1 set output
         func_expr.output = "out1"
@@ -151,7 +153,9 @@ class StatementBinderTests(unittest.TestCase):
 
         mock_get_name.assert_called_with(func_expr.name)
         mock_get_udf_outputs.assert_called_with(udf_obj)
-        mock_load_udf_class_from_file.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
+        mock_load_udf_class_from_file.assert_called_with(
+            udf_obj.impl_file_path, udf_obj.name
+        )
         self.assertEqual(func_expr.output_objs, [obj1])
         print(str(func_expr.alias))
         self.assertEqual(
@@ -168,7 +172,9 @@ class StatementBinderTests(unittest.TestCase):
 
         mock_get_name.assert_called_with(func_expr.name)
         mock_get_udf_outputs.assert_called_with(udf_obj)
-        mock_load_udf_class_from_file.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
+        mock_load_udf_class_from_file.assert_called_with(
+            udf_obj.impl_file_path, udf_obj.name
+        )
         self.assertEqual(func_expr.output_objs, func_ouput_objs)
         self.assertEqual(
             func_expr.alias,

--- a/test/binder/test_statement_binder.py
+++ b/test/binder/test_statement_binder.py
@@ -122,8 +122,8 @@ class StatementBinderTests(unittest.TestCase):
             mock_binder.assert_called_with(stmt.explainable_stmt)
 
     @patch("eva.binder.statement_binder.CatalogManager")
-    @patch("eva.binder.statement_binder.path_to_class")
-    def test_bind_func_expr(self, mock_path_to_class, mock_catalog):
+    @patch("eva.binder.statement_binder.load_udf_class_from_file")
+    def test_bind_func_expr(self, mock_load_udf_class_from_file, mock_catalog):
         # setup
         func_expr = MagicMock(
             name="func_expr", alias=Alias("func_expr"), output_col_aliases=[]
@@ -142,7 +142,7 @@ class StatementBinderTests(unittest.TestCase):
             mock_catalog().get_udf_io_catalog_output_entries
         ) = MagicMock()
         mock_get_udf_outputs.return_value = func_ouput_objs
-        mock_path_to_class.return_value.return_value = "path_to_class"
+        mock_load_udf_class_from_file.return_value.return_value = "load_udf_class_from_file"
 
         # Case 1 set output
         func_expr.output = "out1"
@@ -151,14 +151,14 @@ class StatementBinderTests(unittest.TestCase):
 
         mock_get_name.assert_called_with(func_expr.name)
         mock_get_udf_outputs.assert_called_with(udf_obj)
-        mock_path_to_class.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
+        mock_load_udf_class_from_file.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
         self.assertEqual(func_expr.output_objs, [obj1])
         print(str(func_expr.alias))
         self.assertEqual(
             func_expr.alias,
             Alias("func_expr", ["out1"]),
         )
-        self.assertEqual(func_expr.function(), "path_to_class")
+        self.assertEqual(func_expr.function(), "load_udf_class_from_file")
 
         # Case 2 output not set
         func_expr.output = None
@@ -168,7 +168,7 @@ class StatementBinderTests(unittest.TestCase):
 
         mock_get_name.assert_called_with(func_expr.name)
         mock_get_udf_outputs.assert_called_with(udf_obj)
-        mock_path_to_class.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
+        mock_load_udf_class_from_file.assert_called_with(udf_obj.impl_file_path, udf_obj.name)
         self.assertEqual(func_expr.output_objs, func_ouput_objs)
         self.assertEqual(
             func_expr.alias,
@@ -177,12 +177,12 @@ class StatementBinderTests(unittest.TestCase):
                 ["out1", "out2"],
             ),
         )
-        self.assertEqual(func_expr.function(), "path_to_class")
+        self.assertEqual(func_expr.function(), "load_udf_class_from_file")
 
         # Raise error if the class object cannot be created
-        mock_path_to_class.reset_mock()
-        mock_error_msg = "mock_path_to_class_error"
-        mock_path_to_class.side_effect = MagicMock(
+        mock_load_udf_class_from_file.reset_mock()
+        mock_error_msg = "mock_load_udf_class_from_file_error"
+        mock_load_udf_class_from_file.side_effect = MagicMock(
             side_effect=RuntimeError(mock_error_msg)
         )
         binder = StatementBinder(StatementBinderContext())

--- a/test/executor/test_create_udf_executor.py
+++ b/test/executor/test_create_udf_executor.py
@@ -21,15 +21,15 @@ from eva.executor.create_udf_executor import CreateUDFExecutor
 
 class CreateUdfExecutorTest(unittest.TestCase):
     @patch("eva.executor.create_udf_executor.CatalogManager")
-    @patch("eva.executor.create_udf_executor.path_to_class")
-    def test_should_create_udf(self, path_to_class_mock, mock):
+    @patch("eva.executor.create_udf_executor.load_udf_class_from_file")
+    def test_should_create_udf(self, load_udf_class_from_file_mock, mock):
         catalog_instance = mock.return_value
         catalog_instance.get_udf_catalog_entry_by_name.return_value = None
         catalog_instance.insert_udf_catalog_entry.return_value = "udf"
         impl_path = MagicMock()
         abs_path = impl_path.absolute.return_value = MagicMock()
         abs_path.as_posix.return_value = "test.py"
-        path_to_class_mock.return_value.return_value = "mock_class"
+        load_udf_class_from_file_mock.return_value.return_value = "mock_class"
         plan = type(
             "CreateUDFPlan",
             (),

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -21,11 +21,11 @@ from mock import MagicMock, patch
 
 from eva.readers.opencv_reader import OpenCVReader
 from eva.utils.generic_utils import (
-    validate_kwargs,
     generate_file_path,
     is_gpu_available,
     load_udf_class_from_file,
     str_to_class,
+    validate_kwargs,
 )
 
 

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -44,10 +44,6 @@ class ModulePathTest(unittest.TestCase):
         vl = load_udf_class_from_file("eva/readers/opencv_reader.py")
         assert vl.__qualname__ == OpenCVReader.__qualname__
 
-    def test_should_raise_if_specified_class_does_not_exists(self):
-        with self.assertRaises(RuntimeError):
-            load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCV")
-
     def test_should_raise_if_class_does_not_exists(self):
         with self.assertRaises(RuntimeError):
             # eva/utils/s3_utils.py has no class in it

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -33,19 +33,16 @@ class ModulePathTest(unittest.TestCase):
         vl = str_to_class("eva.readers.opencv_reader.OpenCVReader")
         self.assertEqual(vl, OpenCVReader)
 
-
     def test_should_return_correct_class_for_path(self):
         vl = load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCVReader")
         # Can't check that v1 = OpenCVReader because the above function returns opencv_reader.OpenCVReader instead of eva.readers.opencv_reader.OpenCVReader
-        # So we check the qualname instead, qualname is the path to the class including the module name 
+        # So we check the qualname instead, qualname is the path to the class including the module name
         # Ref: https://peps.python.org/pep-3155/#rationale
         assert vl.__qualname__ == OpenCVReader.__qualname__
-
 
     def test_should_return_correct_class_for_path_without_classname(self):
         vl = load_udf_class_from_file("eva/readers/opencv_reader.py")
         assert vl.__qualname__ == OpenCVReader.__qualname__
-
 
     def test_should_raise_if_specified_class_does_not_exists(self):
         with self.assertRaises(RuntimeError):

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -21,6 +21,7 @@ from mock import MagicMock, patch
 
 from eva.readers.opencv_reader import OpenCVReader
 from eva.utils.generic_utils import (
+    validate_kwargs,
     generate_file_path,
     is_gpu_available,
     load_udf_class_from_file,
@@ -29,6 +30,10 @@ from eva.utils.generic_utils import (
 
 
 class ModulePathTest(unittest.TestCase):
+    def test_helper_validates_kwargs(self):
+        with self.assertRaises(TypeError):
+            validate_kwargs({"a": 1, "b": 2}, ["a"], "Invalid keyword argument:")
+
     def test_should_return_correct_class_for_string(self):
         vl = str_to_class("eva.readers.opencv_reader.OpenCVReader")
         self.assertEqual(vl, OpenCVReader)
@@ -43,6 +48,10 @@ class ModulePathTest(unittest.TestCase):
     def test_should_return_correct_class_for_path_without_classname(self):
         vl = load_udf_class_from_file("eva/readers/opencv_reader.py")
         assert vl.__qualname__ == OpenCVReader.__qualname__
+
+    def test_should_raise_on_missing_file(self):
+        with self.assertRaises(RuntimeError):
+            load_udf_class_from_file("eva/readers/opencv_reader_abdfdsfds.py")
 
     def test_should_raise_if_class_does_not_exists(self):
         with self.assertRaises(RuntimeError):

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -23,7 +23,7 @@ from eva.readers.opencv_reader import OpenCVReader
 from eva.utils.generic_utils import (
     generate_file_path,
     is_gpu_available,
-    path_to_class,
+    load_udf_class_from_file,
     str_to_class,
 )
 
@@ -38,12 +38,12 @@ class ModulePathTest(unittest.TestCase):
                    instead of eva.readers.opencv_reader.OpenCVReader"
     )
     def test_should_return_correct_class_for_path(self):
-        vl = path_to_class("eva/readers/opencv_reader.py", "OpenCVReader")
+        vl = load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCVReader")
         self.assertEqual(vl, OpenCVReader)
 
     def test_should_raise_if_class_does_not_exists(self):
         with self.assertRaises(RuntimeError):
-            path_to_class("eva/readers/opencv_reader.py", "OpenCV")
+            load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCV")
 
     def test_should_use_torch_to_check_if_gpu_is_available(self):
         # Emulate a missing import

--- a/test/utils/test_generic_utils.py
+++ b/test/utils/test_generic_utils.py
@@ -33,17 +33,35 @@ class ModulePathTest(unittest.TestCase):
         vl = str_to_class("eva.readers.opencv_reader.OpenCVReader")
         self.assertEqual(vl, OpenCVReader)
 
-    @unittest.skip(
-        "This returns opecv_reader.OpenCVReader \
-                   instead of eva.readers.opencv_reader.OpenCVReader"
-    )
+
     def test_should_return_correct_class_for_path(self):
         vl = load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCVReader")
-        self.assertEqual(vl, OpenCVReader)
+        # Can't check that v1 = OpenCVReader because the above function returns opencv_reader.OpenCVReader instead of eva.readers.opencv_reader.OpenCVReader
+        # So we check the qualname instead, qualname is the path to the class including the module name 
+        # Ref: https://peps.python.org/pep-3155/#rationale
+        assert vl.__qualname__ == OpenCVReader.__qualname__
+
+
+    def test_should_return_correct_class_for_path_without_classname(self):
+        vl = load_udf_class_from_file("eva/readers/opencv_reader.py")
+        assert vl.__qualname__ == OpenCVReader.__qualname__
+
+
+    def test_should_raise_if_specified_class_does_not_exists(self):
+        with self.assertRaises(RuntimeError):
+            load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCV")
 
     def test_should_raise_if_class_does_not_exists(self):
         with self.assertRaises(RuntimeError):
-            load_udf_class_from_file("eva/readers/opencv_reader.py", "OpenCV")
+            # eva/utils/s3_utils.py has no class in it
+            # if this test fails due to change in s3_utils.py, change the file to something else
+            load_udf_class_from_file("eva/utils/s3_utils.py")
+
+    def test_should_raise_if_multiple_classes_exist_and_no_class_mentioned(self):
+        with self.assertRaises(RuntimeError):
+            # eva/utils/generic_utils.py has multiple classes in it
+            # if this test fails due to change in generic_utils.py, change the file to something else
+            load_udf_class_from_file("eva/utils/generic_utils.py")
 
     def test_should_use_torch_to_check_if_gpu_is_available(self):
         # Emulate a missing import


### PR DESCRIPTION
Note: Inspired from work on decorators coming in another PR.

### Current Behavior
We currently enforce that the UDF be named same as the class in the impl file. This seems like an unnecessary restriction. 

### Modification
This PR introduces the following way of loading the UDF:
- Check if a class with UDF name exists, if yes, loads that.
- If the class with UDF name doesn't exist,
       - If the file has a single class load that. 
       - Else, raise an error asking user to specify the class name as UDF in case of multiple classes in file. 
       
### Testing
Added test cases. 
       
   