### PR TITLE
feat: Ray integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
             v: "3.10"
             mode: "RAY TEST"
         - Pip
-        - Windows   
+        - Windows
         #- test:
         #    name: "Linux -  v3.11"  # missing Torchvision
         #    v: "3.11"
@@ -80,31 +80,31 @@ jobs:
             pip install ".[dev]"
 
       # Enable Ray conditionally
-      when:
-        condition:
-          - equal: [ RAY TEST, << parameters.mode >>]
-        steps:
-          - run: 
-            name: Enable Ray setting in the config.yml file
-            command: |
-              python -c "import yaml;f = open('eva/eva.yml', 'r+');config_obj = yaml.load(f, Loader=yaml.FullLoader);config_obj['experimental']['ray'] = True;f.seek(0);f.write(yaml.dump(config_obj));f.truncate();"
+      - when:
+          condition:
+            equal: [ RAY TEST, << parameters.mode >> ]
+          steps:
+            - run:
+                name: Enable Ray setting in the config.yml file
+                command: |
+                  python -c "import yaml;f = open('eva/eva.yml', 'r+');config_obj = yaml.load(f, Loader=yaml.FullLoader);config_obj['experimental']['ray'] = True;f.seek(0);f.write(yaml.dump(config_obj));f.truncate();"
 
       - run:
           name: Test and upload coverage report to coveralls
           command: |
             source test_evadb/bin/activate
             bash script/test/test.sh -m "<< parameters.mode >>"
-    
+
   Windows:
     executor: win/default
     parameters:
       v:
         type: string
-        default: "3.10" 
+        default: "3.10"
     steps:
       - checkout
 
-      - run: 
+      - run:
           name: Test windows
           command: |
             Set-StrictMode -Version Latest
@@ -112,7 +112,7 @@ jobs:
             pip install virtualenv
             virtualenv test_evadb
             test_evadb\Scripts\activate
-            pip install ".[dev]"       
+            pip install ".[dev]"
             bash script\test\test.sh
 
   Pip:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
       - run:
           name: Test and upload coverage report to coveralls
           command: |
+            export PYTHONUNBUFFERED=1
             source test_evadb/bin/activate
             bash script/test/test.sh -m "<< parameters.mode >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,11 @@ workflows:
             name: "Linter | Linux"
             v: "3.10"
             mode: "LINTER"
+        ### RAY
+        - test:
+            name: "Test | Ray | v3.10 | Linux"
+            v: "3.10"
+            mode: "RAY TEST"
         - Pip
         - Windows   
         #- test:
@@ -73,6 +78,16 @@ jobs:
             "python<< parameters.v >>" -m venv test_evadb
             source test_evadb/bin/activate
             pip install ".[dev]"
+
+      # Enable Ray conditionally
+      when:
+        condition:
+          - equal: [ RAY TEST, << parameters.mode >>]
+        steps:
+          - run: 
+            name: Enable Ray setting in the config.yml file
+            command: |
+              python -c "import yaml;f = open('eva/eva.yml', 'r+');config_obj = yaml.load(f, Loader=yaml.FullLoader);config_obj['experimental']['ray'] = True;f.seek(0);f.write(yaml.dump(config_obj));f.truncate();"
 
       - run:
           name: Test and upload coverage report to coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ workflows:
         - test:
             name: "Test | Ray | v3.10 | Linux"
             v: "3.10"
-            mode: "RAY TEST"
+            mode: "TEST"
+            ray_enabled: true
         - Pip
         - Windows
         #- test:
@@ -64,6 +65,9 @@ jobs:
       mode:
         type: string
         default: "ALL"
+      ray_enabled:
+        type: boolean
+        default: false
     resource_class: large
     docker:
       # https://circleci.com/docs/circleci-images#language-image-variants
@@ -81,8 +85,7 @@ jobs:
 
       # Enable Ray conditionally
       - when:
-          condition:
-            equal: [ RAY TEST, << parameters.mode >> ]
+          condition: << parameters.ray_enabled >>
           steps:
             - run:
                 name: Enable Ray setting in the config.yml file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ workflows:
         - test:
             name: "Test | Ray | v3.10 | Linux"
             v: "3.10"
-            mode: "TEST"
-            ray_enabled: true
+            mode: "RAY"
         - Pip
         - Windows
         #- test:
@@ -65,9 +64,6 @@ jobs:
       mode:
         type: string
         default: "ALL"
-      ray_enabled:
-        type: boolean
-        default: false
     resource_class: large
     docker:
       # https://circleci.com/docs/circleci-images#language-image-variants
@@ -85,7 +81,8 @@ jobs:
 
       # Enable Ray conditionally
       - when:
-          condition: << parameters.ray_enabled >>
+          condition: 
+            equal: [ RAY, << parameters.mode >> ]
           steps:
             - run:
                 name: Enable Ray setting in the config.yml file
@@ -96,7 +93,6 @@ jobs:
       - run:
           name: Test and upload coverage report to coveralls
           command: |
-            export PYTHONUNBUFFERED=1
             source test_evadb/bin/activate
             bash script/test/test.sh -m "<< parameters.mode >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
             - run:
                 name: Enable Ray setting in the config.yml file
                 command: |
+                  source test_evadb/bin/activate
                   python -c "import yaml;f = open('eva/eva.yml', 'r+');config_obj = yaml.load(f, Loader=yaml.FullLoader);config_obj['experimental']['ray'] = True;f.seek(0);f.write(yaml.dump(config_obj));f.truncate();"
 
       - run:

--- a/eva/eva.yml
+++ b/eva/eva.yml
@@ -13,7 +13,7 @@ executor:
   # batch size used for gpu_operations
   gpu_batch_size: 1
 
-  gpus: { "127.0.0.1": [0] }
+  gpu_ids: [0, 1]
 
 storage:
   tmp_dir: ""

--- a/eva/executor/execution_context.py
+++ b/eva/executor/execution_context.py
@@ -50,7 +50,7 @@ class Context:
     def _populate_gpu_from_env(self) -> List:
         # Populate GPU IDs from env variable.
         gpu_conf = map(
-            lambda x: x.strip(), os.environ.get("GPU_DEVICES", "").strip().split(",")
+            lambda x: x.strip(), os.environ.get("CUDA_VISIBLE_DEVICES", "").strip().split(",")
         )
         gpu_conf = list(filter(lambda x: x, gpu_conf))
         gpu_conf = [int(gpu_id) for gpu_id in gpu_conf]

--- a/eva/executor/execution_context.py
+++ b/eva/executor/execution_context.py
@@ -44,7 +44,6 @@ class Context:
     def _populate_gpu_from_config(self) -> List:
         # Populate GPU IDs from yaml config file.
         gpu_conf = self._config_manager.get_value("executor", "gpu_ids")
-        gpu_conf = gpu_conf if gpu_conf else []
         availble_gpus = [i for i in range(get_gpu_count())]
         return list(set(availble_gpus) & set(gpu_conf))
 
@@ -56,7 +55,7 @@ class Context:
         gpu_conf = list(filter(lambda x: x, gpu_conf))
         gpu_conf = [int(gpu_id) for gpu_id in gpu_conf]
         availble_gpus = [i for i in range(get_gpu_count())]
-        return list(set(gpu_conf) & set(availble_gpus))
+        return list(set(availble_gpus) & set(gpu_conf))
 
     def _populate_gpu_ids(self) -> List:
         # Populate available GPU IDs from Torch library. Then, select subset of GPUs

--- a/eva/executor/execution_context.py
+++ b/eva/executor/execution_context.py
@@ -19,7 +19,7 @@ from typing import List, Set
 
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.constants import NO_GPU
-from eva.utils.generic_utils import is_gpu_available
+from eva.utils.generic_utils import is_gpu_available, get_gpu_count
 
 
 class Context:
@@ -42,30 +42,26 @@ class Context:
     def gpus(self):
         return self._gpus
 
-    def _possible_addresses(self) -> Set:
-        host = socket.gethostname()
-        result_address = {host}
-        true_host, aliases, address = socket.gethostbyaddr(host)
-        result_address.add(true_host)
-        result_address.update(set(aliases).union(set(address)))
-        return result_address
-
     def _populate_gpu_from_config(self) -> List:
-        gpu_conf = self._config_manager.get_value("executor", "gpus")
-        gpu_conf = gpu_conf if gpu_conf else {}
-        this_address = self._possible_addresses()
-        intersection_addresses = this_address.intersection(gpu_conf.keys())
-        if len(intersection_addresses) != 0:
-            return [str(gpu) for gpu in gpu_conf.get(intersection_addresses.pop())]
-        return []
+        # Populate GPU IDs from yaml config file.
+        gpu_conf = self._config_manager.get_value("executor", "gpu_ids")
+        gpu_conf = gpu_conf if gpu_conf else []
+        availble_gpus = [i for i in range(get_gpu_count())]
+        return list(set(availble_gpus) & set(gpu_conf))
 
     def _populate_gpu_from_env(self) -> List:
-        gpus = map(
+        # Populate GPU IDs from env variable.
+        gpu_conf = map(
             lambda x: x.strip(), os.environ.get("GPU_DEVICES", "").strip().split(",")
         )
-        return list(filter(lambda x: x, gpus))
+        gpu_conf = list(filter(lambda x: x, gpu_conf))
+        gpu_conf = [int(gpu_id) for gpu_id in gpu_conf]
+        availble_gpus = [i for i in range(get_gpu_count())]
+        return list(set(gpu_conf) & set(availble_gpus))
 
     def _populate_gpu_ids(self) -> List:
+        # Populate available GPU IDs from Torch library. Then, select subset of GPUs
+        # from available GPUs based on user configuration.
         if not is_gpu_available():
             return []
         gpus = self._populate_gpu_from_config()

--- a/eva/executor/execution_context.py
+++ b/eva/executor/execution_context.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 import os
 import random
-import socket
-from typing import List, Set
+from typing import List
 
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.constants import NO_GPU
-from eva.utils.generic_utils import is_gpu_available, get_gpu_count
+from eva.utils.generic_utils import get_gpu_count, is_gpu_available
 
 
 class Context:

--- a/eva/executor/execution_context.py
+++ b/eva/executor/execution_context.py
@@ -50,7 +50,8 @@ class Context:
     def _populate_gpu_from_env(self) -> List:
         # Populate GPU IDs from env variable.
         gpu_conf = map(
-            lambda x: x.strip(), os.environ.get("CUDA_VISIBLE_DEVICES", "").strip().split(",")
+            lambda x: x.strip(),
+            os.environ.get("CUDA_VISIBLE_DEVICES", "").strip().split(","),
         )
         gpu_conf = list(filter(lambda x: x, gpu_conf))
         gpu_conf = [int(gpu_id) for gpu_id in gpu_conf]

--- a/eva/executor/faiss_index_scan_executor.py
+++ b/eva/executor/faiss_index_scan_executor.py
@@ -72,7 +72,7 @@ class FaissIndexScanExecutor(AbstractExecutor):
         # Load projected columns from disk and join with search results.
         row_id_col_name = None
         res_row_list = [None for _ in range(self.limit_count.value)]
-        for batch in self.children[0].exec():
+        for batch in self.children[0].exec(**kwargs):
             column_list = batch.columns
             if not row_id_col_name:
                 row_id_alias = get_row_id_column_alias(column_list)

--- a/eva/executor/groupby_executor.py
+++ b/eva/executor/groupby_executor.py
@@ -39,7 +39,7 @@ class GroupByExecutor(AbstractExecutor):
         child_executor = self.children[0]
 
         buffer = Batch(pd.DataFrame())
-        for batch in child_executor.exec():
+        for batch in child_executor.exec(**kwargs):
             new_batch = buffer + batch
             # We assume that all the segments exactly of segment_length size
             # and discard any dangling frames in the end.

--- a/eva/executor/limit_executor.py
+++ b/eva/executor/limit_executor.py
@@ -36,7 +36,7 @@ class LimitExecutor(AbstractExecutor):
         child_executor = self.children[0]
         remaining_tuples = self._limit_count
         # aggregates the batches into one large batch
-        for batch in child_executor.exec():
+        for batch in child_executor.exec(**kwargs):
             if len(batch) > remaining_tuples:
                 yield batch[:remaining_tuples]
                 return

--- a/eva/executor/nested_loop_join_executor.py
+++ b/eva/executor/nested_loop_join_executor.py
@@ -28,8 +28,8 @@ class NestedLoopJoinExecutor(AbstractExecutor):
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
         outer = self.children[0]
         inner = self.children[1]
-        for row1 in outer.exec():
-            for row2 in inner.exec():
+        for row1 in outer.exec(**kwargs):
+            for row2 in inner.exec(**kwargs):
                 result_batch = Batch.join(row1, row2)
                 result_batch.reset_index()
                 result_batch = apply_predicate(result_batch, self.predicate)

--- a/eva/executor/orderby_executor.py
+++ b/eva/executor/orderby_executor.py
@@ -75,7 +75,7 @@ class OrderByExecutor(AbstractExecutor):
         aggregated_batch_list = []
 
         # aggregates the batches into one large batch
-        for batch in child_executor.exec():
+        for batch in child_executor.exec(**kwargs):
             self.batch_sizes.append(len(batch))
             aggregated_batch_list.append(batch)
         aggregated_batch = Batch.concat(aggregated_batch_list, copy=False)

--- a/eva/executor/predicate_executor.py
+++ b/eva/executor/predicate_executor.py
@@ -29,7 +29,7 @@ class PredicateExecutor(AbstractExecutor):
 
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
         child_executor = self.children[0]
-        for batch in child_executor.exec(*args, **kwargs):
+        for batch in child_executor.exec(**kwargs):
             batch = apply_predicate(batch, self.predicate)
             if not batch.empty():
                 yield batch

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -46,6 +46,9 @@ class QueueReaderExecutor(AbstractExecutor):
             if next_item is StageCompleteSignal:
                 iq.put(StageCompleteSignal)
                 break
+            elif isinstance(next_item, ExecutorError):
+                # Raise ExecutorError immediately from queue.
+                raise next_item
             else:
                 yield next_item
 
@@ -107,6 +110,7 @@ class ExchangeExecutor(AbstractExecutor):
             if res is StageCompleteSignal:
                 break
             elif isinstance(res, ExecutorError):
+                # Raise ExecutorError for the topmost Exchange.
                 raise res
             else:
                 yield res

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -17,13 +17,13 @@ from typing import Iterator
 from ray.util.queue import Queue
 
 from eva.executor.abstract_executor import AbstractExecutor
+from eva.executor.executor_utils import ExecutorError
 from eva.experimental.ray.executor.ray_stage import (
     StageCompleteSignal,
     ray_stage,
     ray_stage_wait_and_alert,
 )
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
-from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 
 

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -17,6 +17,7 @@ from typing import Iterator
 from ray.util.queue import Queue
 
 from eva.executor.abstract_executor import AbstractExecutor
+from eva.executor.executor_utils import ExecutorError
 from eva.experimental.ray.executor.ray_stage import (
     StageCompleteSignal,
     ray_stage,
@@ -24,7 +25,6 @@ from eva.experimental.ray.executor.ray_stage import (
 )
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
 from eva.models.storage.batch import Batch
-from eva.executor.executor_utils import ExecutorError
 
 
 class QueueReaderExecutor(AbstractExecutor):

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -17,7 +17,6 @@ from typing import Iterator
 from ray.util.queue import Queue
 
 from eva.executor.abstract_executor import AbstractExecutor
-from eva.executor.executor_utils import ExecutorError
 from eva.experimental.ray.executor.ray_stage import (
     StageCompleteSignal,
     ray_stage,
@@ -25,30 +24,26 @@ from eva.experimental.ray.executor.ray_stage import (
 )
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
 from eva.models.storage.batch import Batch
+from eva.executor.executor_utils import ExecutorError
 
 
 class QueueReaderExecutor(AbstractExecutor):
     def __init__(self):
         super().__init__(None)
 
-        # Index of input queue.
-        self.q_idx = None
-
     def exec(self, **kwargs) -> Iterator[Batch]:
         assert (
             "input_queues" in kwargs
         ), "Invalid ray exectuion stage. No input_queue found"
         input_queues = kwargs["input_queues"]
-        iq = input_queues[self.q_idx]
+        assert len(input_queues) == 1, "Not support mulitple input queues yet"
+        iq = input_queues[0]
 
         while True:
             next_item = iq.get(block=True)
             if next_item is StageCompleteSignal:
                 iq.put(StageCompleteSignal)
                 break
-            elif isinstance(next_item, ExecutorError):
-                # Raise ExecutorError immediately from queue.
-                raise next_item
             else:
                 yield next_item
 
@@ -66,36 +61,25 @@ class ExchangeExecutor(AbstractExecutor):
         self.ray_conf = node.ray_conf
         super().__init__(node)
 
-    def _find_all_parent_executor_of_exchange(self, curr_exec):
-        # Traverse the query execution tree in a DFS manner. This
-        # function will return the parent executor of ExchangeExecutor,
-        # which will later be inserted a queue reader.
-
-        # Start with checking if current executor has any child.
-        if len(curr_exec.children) > 0:
-            # Check if child executor is ExchangeExecutor. If so, return.
-            # Otherwise, traverse further down.
-            if isinstance(curr_exec.children[0], ExchangeExecutor):
-                yield curr_exec
-            else:
-                for child in curr_exec.children:
-                    yield from self._find_all_parent_executor_of_exchange(child)
-
     def exec(self, is_top=True) -> Iterator[Batch]:
         assert (
             len(self.children) == 1
         ), "Exchange executor does not support children != 1"
 
-        # Find all parent of ExchangeExecutor below current executor.
-        # Attach a queue reader to those parent executors.
+        # Find the exchange exector below the tree
+        curr_exec = self
         input_queues = []
-        for parent_exec in self._find_all_parent_executor_of_exchange(self):
-            iq = yield from parent_exec.children[0].exec(is_top=False)
+        while len(curr_exec.children) > 0 and not isinstance(
+            curr_exec.children[0], ExchangeExecutor
+        ):
+            curr_exec = curr_exec.children[0]
+
+        if len(curr_exec.children) > 0:
+            iq = yield from curr_exec.children[0].exec(is_top=False)
             input_queues.append(iq)
             queue_exec = QueueReaderExecutor()
-            # Set queue index if an executor has multiple input executors.
-            queue_exec.q_idx = len(input_queues) - 1
-            parent_exec.children = [queue_exec]
+            curr_exec.children = [queue_exec]
+            # curr_exec.append_child(queue_exec)
 
         output_queue = Queue(maxsize=100)
         ray_task = []
@@ -111,7 +95,6 @@ class ExchangeExecutor(AbstractExecutor):
             if res is StageCompleteSignal:
                 break
             elif isinstance(res, ExecutorError):
-                # Raise ExecutorError for the topmost Exchange.
                 raise res
             else:
                 yield res

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -23,6 +23,7 @@ from eva.experimental.ray.executor.ray_stage import (
     ray_stage_wait_and_alert,
 )
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
+from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 
 
@@ -105,6 +106,8 @@ class ExchangeExecutor(AbstractExecutor):
             res = output_queue.get(block=True)
             if res is StageCompleteSignal:
                 break
+            elif isinstance(res, ExecutorError):
+                raise res
             else:
                 yield res
         else:

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -93,6 +93,7 @@ class ExchangeExecutor(AbstractExecutor):
             iq = yield from parent_exec.children[0].exec(is_top=False)
             input_queues.append(iq)
             queue_exec = QueueReaderExecutor()
+            # Set queue index if an executor has multiple input executors.
             queue_exec.q_idx = len(input_queues) - 1
             parent_exec.children = [queue_exec]
 

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -44,6 +44,9 @@ class QueueReaderExecutor(AbstractExecutor):
             if next_item is StageCompleteSignal:
                 iq.put(StageCompleteSignal)
                 break
+            elif isinstance(next_item, ExecutorError):
+                iq.put(next_item)
+                raise next_item
             else:
                 yield next_item
 

--- a/eva/experimental/ray/executor/exchange_executor.py
+++ b/eva/experimental/ray/executor/exchange_executor.py
@@ -69,7 +69,6 @@ class ExchangeExecutor(AbstractExecutor):
 
         # Start with checking if current executor has any child.
         if len(curr_exec.children) > 0:
-
             # Check if child executor is ExchangeExecutor. If so, return.
             # Otherwise, traverse further down.
             if isinstance(curr_exec.children[0], ExchangeExecutor):
@@ -77,7 +76,6 @@ class ExchangeExecutor(AbstractExecutor):
             else:
                 for child in curr_exec.children:
                     yield from self._find_all_parent_executor_of_exchange(child)
-
 
     def exec(self, is_top=True) -> Iterator[Batch]:
         assert (

--- a/eva/experimental/ray/executor/ray_stage.py
+++ b/eva/experimental/ray/executor/ray_stage.py
@@ -15,9 +15,8 @@
 from typing import Callable, List
 
 import ray
-
-from ray.util.queue import Queue
 from ray.exceptions import RayError
+from ray.util.queue import Queue
 
 from eva.executor.executor_utils import ExecutorError
 

--- a/eva/experimental/ray/executor/ray_stage.py
+++ b/eva/experimental/ray/executor/ray_stage.py
@@ -15,8 +15,8 @@
 from typing import Callable, List
 
 import ray
-from ray.util.queue import Queue
 from ray.exceptions import RayError
+from ray.util.queue import Queue
 
 from eva.executor.executor_utils import ExecutorError
 

--- a/eva/experimental/ray/executor/ray_stage.py
+++ b/eva/experimental/ray/executor/ray_stage.py
@@ -33,9 +33,6 @@ def ray_stage_wait_and_alert(tasks: ray.ObjectRef, output_queue: Queue):
 def ray_stage(
     executor: Callable, input_queues: List[Queue], output_queues: List[Queue]
 ):
-    if len(input_queues) > 1 or len(output_queues) > 1:
-        raise NotImplementedError
-
     gen = executor(input_queues=input_queues)
     for next_item in gen:
         for oq in output_queues:

--- a/eva/experimental/ray/executor/ray_stage.py
+++ b/eva/experimental/ray/executor/ray_stage.py
@@ -15,8 +15,8 @@
 from typing import Callable, List
 
 import ray
-from ray.exceptions import RayError
 from ray.util.queue import Queue
+from ray.exceptions import RayError
 
 from eva.executor.executor_utils import ExecutorError
 
@@ -40,6 +40,9 @@ def ray_stage_wait_and_alert(tasks: ray.ObjectRef, output_queue: Queue):
 def ray_stage(
     executor: Callable, input_queues: List[Queue], output_queues: List[Queue]
 ):
+    if len(input_queues) > 1 or len(output_queues) > 1:
+        raise NotImplementedError
+
     gen = executor(input_queues=input_queues)
     for next_item in gen:
         for oq in output_queues:

--- a/eva/experimental/ray/executor/ray_stage.py
+++ b/eva/experimental/ray/executor/ray_stage.py
@@ -31,12 +31,12 @@ def ray_stage_wait_and_alert(tasks: ray.ObjectRef, output_queue: Queue):
 
 @ray.remote
 def ray_stage(
-    exectuor: Callable, input_queues: List[Queue], output_queues: List[Queue]
+    executor: Callable, input_queues: List[Queue], output_queues: List[Queue]
 ):
     if len(input_queues) > 1 or len(output_queues) > 1:
         raise NotImplementedError
 
-    gen = exectuor(input_queues=input_queues)
+    gen = executor(input_queues=input_queues)
     for next_item in gen:
         for oq in output_queues:
             oq.put(next_item)

--- a/eva/experimental/ray/optimizer/rules/rules.py
+++ b/eva/experimental/ray/optimizer/rules/rules.py
@@ -21,6 +21,7 @@ from eva.optimizer.rules.pattern import Pattern
 if TYPE_CHECKING:
     from eva.optimizer.optimizer_context import OptimizerContext
 
+from eva.executor.execution_context import Context
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
 from eva.expression.function_expression import FunctionExpression
 from eva.optimizer.operators import (
@@ -33,7 +34,6 @@ from eva.optimizer.rules.rules_base import Promise, Rule, RuleType
 from eva.plan_nodes.project_plan import ProjectPlan
 from eva.plan_nodes.seq_scan_plan import SeqScanPlan
 from eva.plan_nodes.storage_plan import StoragePlan
-from eva.executor.execution_context import Context
 
 
 class LogicalExchangeToPhysical(Rule):
@@ -73,7 +73,7 @@ class LogicalProjectToPhysical(Rule):
             after.append_child(child)
         upper = ExchangePlan(
             parallelism=1,
-            ray_conf={"num_gpus": 1} if Context().gpus else {"num_cpus": 1}, 
+            ray_conf={"num_gpus": 1} if Context().gpus else {"num_cpus": 1},
         )
         upper.append_child(after)
         yield upper
@@ -113,7 +113,9 @@ class LogicalGetToSeqScan(Rule):
         else:
             upper = ExchangePlan(
                 parallelism=2,
-                ray_conf={"num_gpus": 1} if len(Context().gpus) >= 2 else {"num_cpus": 1}, 
+                ray_conf={"num_gpus": 1}
+                if len(Context().gpus) >= 2
+                else {"num_cpus": 1},
             )
             upper.append_child(scan)
             yield upper

--- a/eva/experimental/ray/optimizer/rules/rules.py
+++ b/eva/experimental/ray/optimizer/rules/rules.py
@@ -105,7 +105,8 @@ class LogicalGetToSeqScan(Rule):
         if before.target_list is None or not any(
             [isinstance(expr, FunctionExpression) for expr in before.target_list]
         ):
-            return scan
+            yield scan
+            return
         upper = ExchangePlan(parallelism=2)
         upper.append_child(scan)
         yield upper

--- a/eva/experimental/ray/planner/exchange_plan.py
+++ b/eva/experimental/ray/planner/exchange_plan.py
@@ -29,7 +29,7 @@ class ExchangePlan(AbstractPlan):
     """
 
     def __init__(
-        self, parallelism: int = 1, ray_conf: Dict[str, Any] = {"num_gpus": 1}
+        self, parallelism: int = 1, ray_conf: Dict[str, Any] = {"num_cpus": 1}
     ):
         self.parallelism = parallelism
         self.ray_conf = ray_conf

--- a/eva/optimizer/plan_generator.py
+++ b/eva/optimizer/plan_generator.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 from typing import List
 
+from eva.configuration.configuration_manager import ConfigurationManager
+from eva.experimental.ray.planner.exchange_plan import ExchangePlan
 from eva.optimizer.cost_model import CostModel
 from eva.optimizer.operators import Operator
 from eva.optimizer.optimizer_context import OptimizerContext
@@ -22,8 +24,6 @@ from eva.optimizer.optimizer_tasks import BottomUpRewrite, OptimizeGroup, TopDow
 from eva.optimizer.property import PropertyType
 from eva.optimizer.rules.rules_manager import RulesManager
 from eva.plan_nodes.abstract_plan import AbstractPlan
-from eva.experimental.ray.planner.exchange_plan import ExchangePlan
-from eva.configuration.configuration_manager import ConfigurationManager
 from eva.plan_nodes.create_mat_view_plan import CreateMaterializedViewPlan
 
 
@@ -105,6 +105,7 @@ class PlanGenerator:
 
         # Replace exchange plan.
         if is_branch or is_create_mat:
+
             def _recursive_strip_exchange(plan: AbstractPlan, is_top: bool = False):
                 children = []
                 for child_plan in plan.children:
@@ -120,7 +121,9 @@ class PlanGenerator:
 
                 if isinstance(plan, ExchangePlan):
                     if is_top:
-                        assert len(plan.children) == 1, "Top ExchangePlan can only have 1 child."
+                        assert (
+                            len(plan.children) == 1
+                        ), "Top ExchangePlan can only have 1 child."
                         return plan.children[0]
                     else:
                         return plan.children

--- a/eva/optimizer/plan_generator.py
+++ b/eva/optimizer/plan_generator.py
@@ -115,7 +115,9 @@ class PlanGenerator:
                     plan.append_child(child)
 
                 if isinstance(plan, ExchangePlan):
-                    assert not is_top or len(plan.children) == 1, "Top ExchangePlan can only have 1 child."
+                    assert (
+                        not is_top or len(plan.children) == 1
+                    ), "Top ExchangePlan can only have 1 child."
                     return plan.children
                 else:
                     return [plan]

--- a/eva/plan_nodes/abstract_plan.py
+++ b/eva/plan_nodes/abstract_plan.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
+from typing import List, Any
 from collections import deque
-from typing import Any, List
 
 from eva.plan_nodes.types import PlanOprType
 
@@ -92,19 +92,27 @@ class AbstractPlan(ABC):
                 setattr(result, k, v)
         return result
 
-    def bfs(self):
-        """Returns a generator which visits all nodes in plan tree in
-        breadth-first search (BFS) traversal order.
-
-        Returns:
-            the generator object.
+    def walk(self, bfs=True):
         """
+        Returns a generator which visits all nodes in physical plan tree.
+        """
+        if bfs:
+            yield from self.bfs()
+        else:
+            yield from self.dfs()
+
+    def bfs(self):
         queue = deque([self])
         while queue:
             node = queue.popleft()
             yield node
             for child in node.children:
                 queue.append(child)
+
+    def dfs(self):
+        yield self
+        for child in self.children:
+            yield from child.dfs()
 
     def find_all(self, plan_type: Any):
         """Returns a generator which visits all the nodes in plan tree and yields one

--- a/eva/plan_nodes/abstract_plan.py
+++ b/eva/plan_nodes/abstract_plan.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import List, Any
 from collections import deque
+from typing import Any, List
 
 from eva.plan_nodes.types import PlanOprType
 

--- a/eva/plan_nodes/abstract_plan.py
+++ b/eva/plan_nodes/abstract_plan.py
@@ -15,6 +15,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Any
 from collections import deque
+from typing import List
 
 from eva.plan_nodes.types import PlanOprType
 

--- a/eva/plan_nodes/abstract_plan.py
+++ b/eva/plan_nodes/abstract_plan.py
@@ -15,7 +15,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Any
 from collections import deque
-from typing import List
 
 from eva.plan_nodes.types import PlanOprType
 

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -106,6 +106,17 @@ def is_gpu_available() -> bool:
         return False
 
 
+def get_gpu_count() -> int:
+    """
+    Check number of GPUs through Torch.
+    """
+    try:
+        import torch
+        return torch.cuda.device_count()
+    except ImportError:
+        return 0
+
+
 def generate_file_path(name: str = "") -> Path:
     """Generates a arbitrary file_path(md5 hash) based on the a random salt
     and name

--- a/eva/utils/generic_utils.py
+++ b/eva/utils/generic_utils.py
@@ -112,6 +112,7 @@ def get_gpu_count() -> int:
     """
     try:
         import torch
+
         return torch.cuda.device_count()
     except ImportError:
         return 0

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -77,7 +77,8 @@ then
     if [[ "$MODE" = "TEST" || "$MODE" = "ALL" ]];
     then
         PYTHONPATH=./ pytest --cov-report term-missing:skip-covered  --cov-config=.coveragerc --cov-context=test --cov=eva/ -s -v --log-level=WARNING -m "not benchmark"
-    else
+    elif [[ "$MODE" = "RAY" ]];
+    then
         PYTHONPATH=./ pytest -p no:cov test/ -m "not benchmark"
     fi
 

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -79,7 +79,7 @@ then
         PYTHONPATH=./ pytest --cov-report term-missing:skip-covered  --cov-config=.coveragerc --cov-context=test --cov=eva/ -s -v --log-level=WARNING -m "not benchmark"
     elif [[ "$MODE" = "RAY" ]];
     then
-        PYTHONPATH=./ pytest -p no:cov test/ -m "not benchmark"
+        PYTHONPATH=./ pytest -s -v -p no:cov test/ -m "not benchmark"
     fi
 
     test_code=$?

--- a/script/test/test.sh
+++ b/script/test/test.sh
@@ -77,15 +77,18 @@ then
     if [[ "$MODE" = "TEST" || "$MODE" = "ALL" ]];
     then
         PYTHONPATH=./ pytest --cov-report term-missing:skip-covered  --cov-config=.coveragerc --cov-context=test --cov=eva/ -s -v --log-level=WARNING -m "not benchmark"
-        test_code=$?
-        if [ "$test_code" != "0" ];
-        then
-            echo "PYTEST CODE: --|${test_code}|-- FAILURE"
-            exit $test_code
-        else
-            echo "PYTEST CODE: --|${test_code}|-- SUCCESS"
-        fi
-     fi
+    else
+        PYTHONPATH=./ pytest -p no:cov test/ -m "not benchmark"
+    fi
+
+    test_code=$?
+    if [ "$test_code" != "0" ];
+    then
+        echo "PYTEST CODE: --|${test_code}|-- FAILURE"
+        exit $test_code
+    else
+        echo "PYTEST CODE: --|${test_code}|-- SUCCESS"
+    fi
 # Windows -- no need for coverage report
 else
     PYTHONPATH=./ pytest -p no:cov test/ -m "not benchmark"

--- a/test/executor/test_execution_context.py
+++ b/test/executor/test_execution_context.py
@@ -24,7 +24,7 @@ class ExecutionContextTest(unittest.TestCase):
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpu_devices_gets_populated_from_config(
+    def test_CUDA_VISIBLE_DEVICES_gets_populated_from_config(
         self, gpu_check, get_gpu_count, cfm
     ):
         gpu_check.return_value = True
@@ -38,7 +38,7 @@ class ExecutionContextTest(unittest.TestCase):
     @patch("eva.executor.execution_context.os")
     @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpu_devices_gets_populated_from_environment_if_no_config(
+    def test_CUDA_VISIBLE_DEVICES_gets_populated_from_environment_if_no_config(
         self, is_gpu, get_gpu_count, os, cfm
     ):
         is_gpu.return_value = True
@@ -46,7 +46,7 @@ class ExecutionContextTest(unittest.TestCase):
         get_gpu_count.return_value = 3
         os.environ.get.return_value = "0,1"
         context = Context()
-        os.environ.get.assert_called_with("GPU_DEVICES", "")
+        os.environ.get.assert_called_with("CUDA_VISIBLE_DEVICES", "")
 
         self.assertEqual(context.gpus, [0, 1])
 
@@ -54,7 +54,7 @@ class ExecutionContextTest(unittest.TestCase):
     @patch("eva.executor.execution_context.os")
     @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpu_devices_should_be_empty_if_nothing_provided(
+    def test_CUDA_VISIBLE_DEVICES_should_be_empty_if_nothing_provided(
         self, gpu_check, get_gpu_count, os, cfm
     ):
         gpu_check.return_value = True
@@ -62,7 +62,7 @@ class ExecutionContextTest(unittest.TestCase):
         cfm.return_value.get_value.return_value = []
         os.environ.get.return_value = ""
         context = Context()
-        os.environ.get.assert_called_with("GPU_DEVICES", "")
+        os.environ.get.assert_called_with("CUDA_VISIBLE_DEVICES", "")
 
         self.assertEqual(context.gpus, [])
 
@@ -87,7 +87,7 @@ class ExecutionContextTest(unittest.TestCase):
         cfm.return_value.get_value.return_value = []
         os.environ.get.return_value = ""
         context = Context()
-        os.environ.get.assert_called_with("GPU_DEVICES", "")
+        os.environ.get.assert_called_with("CUDA_VISIBLE_DEVICES", "")
 
         self.assertEqual(context.gpu_device(), NO_GPU)
 

--- a/test/executor/test_execution_context.py
+++ b/test/executor/test_execution_context.py
@@ -24,7 +24,9 @@ class ExecutionContextTest(unittest.TestCase):
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpu_devices_gets_populated_from_config(self, gpu_check, get_gpu_count, cfm):
+    def test_gpu_devices_gets_populated_from_config(
+        self, gpu_check, get_gpu_count, cfm
+    ):
         gpu_check.return_value = True
         get_gpu_count.return_value = 3
         cfm.return_value.get_value.return_value = [0, 1]

--- a/test/executor/test_execution_context.py
+++ b/test/executor/test_execution_context.py
@@ -22,58 +22,42 @@ from eva.executor.execution_context import Context
 
 class ExecutionContextTest(unittest.TestCase):
     @patch("eva.executor.execution_context.ConfigurationManager")
-    @patch("eva.executor.execution_context.socket")
+    @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpu_devices_gets_populated_from_config(self, gpu_check, socket, cfm):
+    def test_gpu_devices_gets_populated_from_config(self, gpu_check, get_gpu_count, cfm):
         gpu_check.return_value = True
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = {"address2": ["0", "1", "2"]}
+        get_gpu_count.return_value = 3
+        cfm.return_value.get_value.return_value = [0, 1]
         context = Context()
 
-        self.assertEqual(context.gpus, ["0", "1", "2"])
+        self.assertEqual(context.gpus, [0, 1])
 
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.os")
-    @patch("eva.executor.execution_context.socket")
+    @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
     def test_gpu_devices_gets_populated_from_environment_if_no_config(
-        self, is_gpu, socket, os, cfm
+        self, is_gpu, get_gpu_count, os, cfm
     ):
         is_gpu.return_value = True
-
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = {"address3": ["0", "1", "2"]}
-        os.environ.get.return_value = "0,1,2"
+        cfm.return_value.get_value.return_value = []
+        get_gpu_count.return_value = 3
+        os.environ.get.return_value = "0,1"
         context = Context()
         os.environ.get.assert_called_with("GPU_DEVICES", "")
 
-        self.assertEqual(context.gpus, ["0", "1", "2"])
+        self.assertEqual(context.gpus, [0, 1])
 
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.os")
-    @patch("eva.executor.execution_context.socket")
+    @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
     def test_gpu_devices_should_be_empty_if_nothing_provided(
-        self, gpu_check, socket, os, cfm
+        self, gpu_check, get_gpu_count, os, cfm
     ):
         gpu_check.return_value = True
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = {"address3": ["0", "1", "2"]}
+        get_gpu_count.return_value = 3
+        cfm.return_value.get_value.return_value = []
         os.environ.get.return_value = ""
         context = Context()
         os.environ.get.assert_called_with("GPU_DEVICES", "")
@@ -82,17 +66,10 @@ class ExecutionContextTest(unittest.TestCase):
 
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.os")
-    @patch("eva.executor.execution_context.socket")
     @patch("eva.executor.execution_context.is_gpu_available")
-    def test_gpus_ignores_config_if_no_gpu_available(self, gpu_check, socket, os, cfm):
+    def test_gpus_ignores_config_if_no_gpu_available(self, gpu_check, os, cfm):
         gpu_check.return_value = False
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = {"address3": ["0", "1", "2"]}
+        cfm.return_value.get_value.return_value = [0, 1, 2]
         os.environ.get.return_value = "0,1,2"
         context = Context()
 
@@ -100,19 +77,12 @@ class ExecutionContextTest(unittest.TestCase):
 
     @patch("eva.executor.execution_context.ConfigurationManager")
     @patch("eva.executor.execution_context.os")
-    @patch("eva.executor.execution_context.socket")
     @patch("eva.executor.execution_context.is_gpu_available")
     def test_gpu_device_should_return_NO_GPU_if_GPU_not_available(
-        self, gpu_check, socket, os, cfm
+        self, gpu_check, os, cfm
     ):
         gpu_check.return_value = True
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = None
+        cfm.return_value.get_value.return_value = []
         os.environ.get.return_value = ""
         context = Context()
         os.environ.get.assert_called_with("GPU_DEVICES", "")
@@ -120,24 +90,15 @@ class ExecutionContextTest(unittest.TestCase):
         self.assertEqual(context.gpu_device(), NO_GPU)
 
     @patch("eva.executor.execution_context.ConfigurationManager")
-    @patch("eva.executor.execution_context.socket")
+    @patch("eva.executor.execution_context.get_gpu_count")
     @patch("eva.executor.execution_context.is_gpu_available")
-    @patch("eva.executor.execution_context.random")
     def test_should_return_random_gpu_ID_if_available(
-        self, random, gpu_check, socket, cfm
+        self, gpu_check, get_gpu_count, cfm
     ):
-        random.choice.return_value = "2"
         gpu_check.return_value = True
-        socket.gethostname.return_value = "host"
-        socket.gethostbyaddr.return_value = (
-            "local",
-            ["another-hostname", "other-possible"],
-            ["address2"],
-        )
-        cfm.return_value.get_value.return_value = {"address2": ["0", "1", "2"]}
+        get_gpu_count.return_value = 1
+        cfm.return_value.get_value.return_value = [0, 1, 2]
         context = Context()
 
         selected_device = context.gpu_device()
-
-        random.choice.assert_called_with(context.gpus)
-        self.assertEqual(selected_device, "2")
+        self.assertEqual(selected_device, 0)

--- a/test/integration_tests/test_array_count.py
+++ b/test/integration_tests/test_array_count.py
@@ -18,6 +18,7 @@ from test.util import (
     create_sample_video,
     file_remove,
     load_udfs_for_testing,
+    shutdown_ray,
 )
 
 import pandas as pd
@@ -26,7 +27,6 @@ import pytest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_array_count.py
+++ b/test/integration_tests/test_array_count.py
@@ -26,6 +26,7 @@ import pytest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -40,6 +41,7 @@ class ArrayCountTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        shutdown_ray()
         execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")
         file_remove("dummy.avi")
 

--- a/test/integration_tests/test_delete_executor.py
+++ b/test/integration_tests/test_delete_executor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import file_remove, load_udfs_for_testing
+from test.util import file_remove, load_udfs_for_testing, shutdown_ray
 
 import numpy as np
 import pytest
@@ -22,7 +22,6 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_delete_executor.py
+++ b/test/integration_tests/test_delete_executor.py
@@ -22,6 +22,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -70,6 +71,7 @@ class DeleteExecutorTest(unittest.TestCase):
         _ = execute_query_fetch_all(query)
 
     def tearDown(self):
+        shutdown_ray()
         file_remove("dummy.avi")
 
     # integration test

--- a/test/integration_tests/test_error_handling_with_ray.py
+++ b/test/integration_tests/test_error_handling_with_ray.py
@@ -12,26 +12,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pathlib import Path
+import time
 import unittest
+from pathlib import Path
 from test.util import (
     create_sample_image,
-    load_udfs_for_testing,
     explain_query_plan,
+    is_ray_stage_running,
+    load_udfs_for_testing,
     shutdown_ray,
-    is_ray_stage_running
 )
 
-import time
 import pytest
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
-from eva.server.command_handler import execute_query_fetch_all
 from eva.executor.executor_utils import ExecutorError
+from eva.server.command_handler import execute_query_fetch_all
 
 
-@pytest.mark.skipif(not ConfigurationManager().get_value("experimental", "ray"), reason="Only test for ray execution.")
+@pytest.mark.skipif(
+    not ConfigurationManager().get_value("experimental", "ray"),
+    reason="Only test for ray execution.",
+)
 class ErrorHandlingRayTests(unittest.TestCase):
     def setUp(self):
         CatalogManager().reset()

--- a/test/integration_tests/test_error_handling_with_ray.py
+++ b/test/integration_tests/test_error_handling_with_ray.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+# Copyright 2018-2022 EVA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+import unittest
+from test.util import (
+    create_sample_image,
+    load_udfs_for_testing,
+    explain_query_plan,
+    shutdown_ray,
+    is_ray_stage_running
+)
+
+import time
+import pytest
+
+from eva.catalog.catalog_manager import CatalogManager
+from eva.configuration.configuration_manager import ConfigurationManager
+from eva.server.command_handler import execute_query_fetch_all
+from eva.executor.executor_utils import ExecutorError
+
+
+@pytest.mark.skipif(not ConfigurationManager().get_value("experimental", "ray"), reason="Only test for ray execution.")
+class ErrorHandlingRayTests(unittest.TestCase):
+    def setUp(self):
+        CatalogManager().reset()
+        ConfigurationManager()
+        # Load built-in UDFs.
+        load_udfs_for_testing(mode="minimal")
+
+        # Deliberately create a faulty path.
+        img_path = create_sample_image()
+        execute_query_fetch_all(f"LOAD IMAGE '{img_path}' INTO testRayErrorHandling;")
+
+        # Forcefully remove file to cause error.
+        Path(img_path).unlink()
+
+    def tearDown(self):
+        shutdown_ray()
+
+        # Drop table.
+        drop_table_query = "DROP TABLE testRayErrorHandling;"
+        execute_query_fetch_all(drop_table_query)
+
+    def test_ray_error_populate_to_all_stages(self):
+        create_udf_query = """CREATE UDF IF NOT EXISTS ToxicityClassifier
+                  INPUT  (text NDARRAY STR(100))
+                  OUTPUT (labels NDARRAY STR(10))
+                  TYPE  Classification
+                  IMPL  'eva/udfs/toxicity_classifier.py';
+        """
+        execute_query_fetch_all(create_udf_query)
+
+        select_query = """SELECT ToxicityClassifier(data) FROM testRayErrorHandling;"""
+        print(explain_query_plan(select_query))
+
+        with self.assertRaises(ExecutorError):
+            _ = execute_query_fetch_all(select_query)
+
+        print("error out")
+        time.sleep(3)
+        self.assertFalse(is_ray_stage_running())

--- a/test/integration_tests/test_error_handling_with_ray.py
+++ b/test/integration_tests/test_error_handling_with_ray.py
@@ -17,7 +17,6 @@ import unittest
 from pathlib import Path
 from test.util import (
     create_sample_image,
-    explain_query_plan,
     is_ray_stage_running,
     load_udfs_for_testing,
     shutdown_ray,
@@ -66,11 +65,9 @@ class ErrorHandlingRayTests(unittest.TestCase):
         execute_query_fetch_all(create_udf_query)
 
         select_query = """SELECT ToxicityClassifier(data) FROM testRayErrorHandling;"""
-        print(explain_query_plan(select_query))
 
         with self.assertRaises(ExecutorError):
             _ = execute_query_fetch_all(select_query)
 
-        print("error out")
         time.sleep(3)
         self.assertFalse(is_ray_stage_running())

--- a/test/integration_tests/test_explain_executor.py
+++ b/test/integration_tests/test_explain_executor.py
@@ -65,7 +65,7 @@ class ExplainExecutorTest(unittest.TestCase):
         select_query = "EXPLAIN SELECT id, data FROM MyVideo"
         batch = execute_query_fetch_all(select_query)
         expected_output = (
-            """|__ SeqScanPlan\n    |__ ExchangePlan\n    |__ StoragePlan\n"""
+            """|__ SeqScanPlan\n    |__ ExchangePlan\n        |__ StoragePlan\n"""
             if ray_enabled
             else """|__ SeqScanPlan\n    |__ StoragePlan\n"""
         )
@@ -78,7 +78,7 @@ class ExplainExecutorTest(unittest.TestCase):
                 select_query, plan_generator=custom_plan_generator
             )
             expected_output = (
-                """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n        |__ ExchangePlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
+                """|__ ExchangePlan\n    |__ ProjectPlan\n        |__ LateralJoinPlan\n            |__ SeqScanPlan\n                |__ ExchangePlan\n                    |__ StoragePlan\n            |__ FunctionScanPlan\n"""
                 if ray_enabled
                 else """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
             )
@@ -98,7 +98,7 @@ class ExplainExecutorTest(unittest.TestCase):
                 select_query, plan_generator=custom_plan_generator
             )
             expected_output = (
-                """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n        |__ ExchangePlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
+                """|__ ExchangePlan\n    |__ ProjectPlan\n        |__ LateralJoinPlan\n            |__ SeqScanPlan\n                |__ ExchangePlan\n                    |__ StoragePlan\n            |__ FunctionScanPlan\n"""
                 if ray_enabled
                 else """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
             )

--- a/test/integration_tests/test_explain_executor.py
+++ b/test/integration_tests/test_explain_executor.py
@@ -78,7 +78,7 @@ class ExplainExecutorTest(unittest.TestCase):
                 select_query, plan_generator=custom_plan_generator
             )
             expected_output = (
-                """|__ ExchangePlan\n    |__ ProjectPlan\n        |__ LateralJoinPlan\n            |__ SeqScanPlan\n                |__ ExchangePlan\n                    |__ StoragePlan\n            |__ FunctionScanPlan\n"""
+                """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
                 if ray_enabled
                 else """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
             )
@@ -98,7 +98,7 @@ class ExplainExecutorTest(unittest.TestCase):
                 select_query, plan_generator=custom_plan_generator
             )
             expected_output = (
-                """|__ ExchangePlan\n    |__ ProjectPlan\n        |__ LateralJoinPlan\n            |__ SeqScanPlan\n                |__ ExchangePlan\n                    |__ StoragePlan\n            |__ FunctionScanPlan\n"""
+                """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
                 if ray_enabled
                 else """|__ ProjectPlan\n    |__ LateralJoinPlan\n        |__ SeqScanPlan\n            |__ StoragePlan\n        |__ FunctionScanPlan\n"""
             )

--- a/test/integration_tests/test_fuzzy_join.py
+++ b/test/integration_tests/test_fuzzy_join.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import unittest
 from pathlib import Path
-from test.util import create_sample_csv, create_sample_video, file_remove
+from test.util import create_sample_csv, create_sample_video, file_remove, shutdown_ray
 
 import pytest
 
@@ -22,7 +22,6 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 EVA_INSTALLATION_DIR = ConfigurationManager().get_value("core", "eva_installation_dir")
 

--- a/test/integration_tests/test_fuzzy_join.py
+++ b/test/integration_tests/test_fuzzy_join.py
@@ -22,6 +22,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 EVA_INSTALLATION_DIR = ConfigurationManager().get_value("core", "eva_installation_dir")
 
@@ -60,6 +61,8 @@ class FuzzyJoinTests(unittest.TestCase):
         execute_query_fetch_all(query)
 
     def tearDown(self):
+        shutdown_ray()
+
         file_remove("dummy.avi")
         file_remove("dummy.csv")
         # clean up

--- a/test/integration_tests/test_insert_executor.py
+++ b/test/integration_tests/test_insert_executor.py
@@ -22,6 +22,7 @@ import pytest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.logging_manager import logger
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -40,6 +41,7 @@ class InsertExecutorTest(unittest.TestCase):
         load_udfs_for_testing(mode="minimal")
 
     def tearDown(self):
+        shutdown_ray()
         file_remove("dummy.avi")
 
     # integration test

--- a/test/integration_tests/test_insert_executor.py
+++ b/test/integration_tests/test_insert_executor.py
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import create_sample_video, file_remove, load_udfs_for_testing, shutdown_ray
+from test.util import (
+    create_sample_video,
+    file_remove,
+    load_udfs_for_testing,
+    shutdown_ray,
+)
 
 import numpy as np
 import pandas as pd

--- a/test/integration_tests/test_insert_executor.py
+++ b/test/integration_tests/test_insert_executor.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import create_sample_video, file_remove, load_udfs_for_testing
+from test.util import create_sample_video, file_remove, load_udfs_for_testing, shutdown_ray
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,6 @@ import pytest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.logging_manager import logger
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_like.py
+++ b/test/integration_tests/test_like.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from test.util import shutdown_ray
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 
 class LikeTest(unittest.TestCase):

--- a/test/integration_tests/test_like.py
+++ b/test/integration_tests/test_like.py
@@ -17,6 +17,7 @@ import unittest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 
 class LikeTest(unittest.TestCase):
@@ -30,6 +31,7 @@ class LikeTest(unittest.TestCase):
         execute_query_fetch_all(f"LOAD IMAGE '{meme2}' INTO MemeImages;")
 
     def tearDown(self):
+        shutdown_ray()
         # clean up
         execute_query_fetch_all("DROP TABLE IF EXISTS MemeImages;")
 

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -30,6 +30,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import ray
+
 from eva.binder.binder_utils import BinderError
 from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
@@ -37,6 +39,7 @@ from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.parser.types import FileFormatType
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -51,6 +54,8 @@ class LoadExecutorTest(unittest.TestCase):
         self.csv_file_path = create_sample_csv()
 
     def tearDown(self):
+        shutdown_ray()
+
         file_remove("dummy.avi")
         file_remove("dummy.csv")
         # clean up

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -24,13 +24,12 @@ from test.util import (
     create_sample_csv,
     create_sample_video,
     file_remove,
+    shutdown_ray,
 )
 
 import numpy as np
 import pandas as pd
 import pytest
-
-import ray
 
 from eva.binder.binder_utils import BinderError
 from eva.catalog.catalog_manager import CatalogManager
@@ -39,7 +38,6 @@ from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.parser.types import FileFormatType
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_mat_executor.py
+++ b/test/integration_tests/test_mat_executor.py
@@ -18,6 +18,7 @@ from test.util import (
     create_sample_video,
     file_remove,
     load_udfs_for_testing,
+    shutdown_ray,
 )
 
 import pandas as pd
@@ -27,7 +28,6 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 

--- a/test/integration_tests/test_mat_executor.py
+++ b/test/integration_tests/test_mat_executor.py
@@ -27,6 +27,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 
@@ -46,6 +47,7 @@ class MaterializedViewTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        shutdown_ray()
         file_remove("dummy.avi")
         file_remove("ua_detrac.mp4")
         execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")

--- a/test/integration_tests/test_open.py
+++ b/test/integration_tests/test_open.py
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import create_sample_image, file_remove, load_udfs_for_testing, shutdown_ray
+from test.util import (
+    create_sample_image,
+    file_remove,
+    load_udfs_for_testing,
+    shutdown_ray,
+)
 
 import numpy as np
 import pandas as pd

--- a/test/integration_tests/test_open.py
+++ b/test/integration_tests/test_open.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import create_sample_image, file_remove, load_udfs_for_testing
+from test.util import create_sample_image, file_remove, load_udfs_for_testing, shutdown_ray
 
 import numpy as np
 import pandas as pd
@@ -47,6 +47,8 @@ class OpenTests(unittest.TestCase):
         )
 
     def tearDown(self):
+        shutdown_ray()
+
         file_remove("dummy.jpg")
 
         # Drop table.

--- a/test/integration_tests/test_optimizer_rules.py
+++ b/test/integration_tests/test_optimizer_rules.py
@@ -19,6 +19,7 @@ import pytest
 from mock import MagicMock, patch
 
 from eva.catalog.catalog_manager import CatalogManager
+from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.expression.comparison_expression import ComparisonExpression
 from eva.optimizer.plan_generator import PlanGenerator
@@ -32,11 +33,13 @@ from eva.optimizer.rules.rules_manager import disable_rules
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.stats import Timer
-from eva.configuration.configuration_manager import ConfigurationManager
 
 
 @pytest.mark.notparallel
-@pytest.mark.skipif(ConfigurationManager().get_value("experimental", "ray"), reason="Not necessary for Ray")
+@pytest.mark.skipif(
+    ConfigurationManager().get_value("experimental", "ray"),
+    reason="Not necessary for Ray",
+)
 class OptimizerRulesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/integration_tests/test_optimizer_rules.py
+++ b/test/integration_tests/test_optimizer_rules.py
@@ -32,6 +32,7 @@ from eva.optimizer.rules.rules_manager import disable_rules
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.stats import Timer
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -46,6 +47,7 @@ class OptimizerRulesTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        shutdown_ray()
         execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")
 
     @patch("eva.expression.function_expression.FunctionExpression.evaluate")

--- a/test/integration_tests/test_optimizer_rules.py
+++ b/test/integration_tests/test_optimizer_rules.py
@@ -32,9 +32,11 @@ from eva.optimizer.rules.rules_manager import disable_rules
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.stats import Timer
+from eva.configuration.configuration_manager import ConfigurationManager
 
 
 @pytest.mark.notparallel
+@pytest.mark.skipif(ConfigurationManager().get_value("experimental", "ray"), reason="Not necessary for Ray")
 class OptimizerRulesTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/integration_tests/test_optimizer_rules.py
+++ b/test/integration_tests/test_optimizer_rules.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import get_physical_query_plan, load_udfs_for_testing
+from test.util import get_physical_query_plan, load_udfs_for_testing, shutdown_ray
 
 import pytest
 from mock import MagicMock, patch
@@ -32,7 +32,6 @@ from eva.optimizer.rules.rules_manager import disable_rules
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.server.command_handler import execute_query_fetch_all
 from eva.utils.stats import Timer
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_pytorch.py
+++ b/test/integration_tests/test_pytorch.py
@@ -28,7 +28,6 @@ from eva.server.command_handler import execute_query_fetch_all
 from eva.udfs.udf_bootstrap_queries import (
     Asl_udf_query,
     Mvit_udf_query,
-    Timestamp_udf_query,
 )
 
 
@@ -293,15 +292,3 @@ class PytorchTest(unittest.TestCase):
                 self.assertTrue(res["toxicityclassifier.labels"][i] == "toxic")
             else:
                 self.assertTrue(res["toxicityclassifier.labels"][i] == "not toxic")
-
-    def test_timestamp_udf(self):
-        execute_query_fetch_all(Timestamp_udf_query)
-
-        select_query = """SELECT id, seconds, Timestamp(seconds)
-                          FROM MyVideo
-                          WHERE Timestamp(seconds) <= "00:00:01"; """
-        # TODO: Check why this does not work
-        #                  AND Timestamp(seconds) < "00:00:03"; """
-        actual_batch = execute_query_fetch_all(select_query)
-
-        self.assertEqual(len(actual_batch), 60)

--- a/test/integration_tests/test_pytorch.py
+++ b/test/integration_tests/test_pytorch.py
@@ -25,10 +25,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
-from eva.udfs.udf_bootstrap_queries import (
-    Asl_udf_query,
-    Mvit_udf_query,
-)
+from eva.udfs.udf_bootstrap_queries import Asl_udf_query, Mvit_udf_query
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_pytorch.py
+++ b/test/integration_tests/test_pytorch.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 from test.markers import windows_skip_marker
-from test.util import file_remove, load_udfs_for_testing
+from test.util import file_remove, load_udfs_for_testing, shutdown_ray
 
 import cv2
 import numpy as np
@@ -30,7 +30,6 @@ from eva.udfs.udf_bootstrap_queries import (
     Mvit_udf_query,
     Timestamp_udf_query,
 )
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_pytorch.py
+++ b/test/integration_tests/test_pytorch.py
@@ -25,7 +25,12 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.configuration.constants import EVA_ROOT_DIR
 from eva.server.command_handler import execute_query_fetch_all
-from eva.udfs.udf_bootstrap_queries import Asl_udf_query, Mvit_udf_query
+from eva.udfs.udf_bootstrap_queries import (
+    Asl_udf_query,
+    Mvit_udf_query,
+    Timestamp_udf_query,
+)
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -50,6 +55,8 @@ class PytorchTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        shutdown_ray()
+
         file_remove("ua_detrac.mp4")
         file_remove("mnist.mp4")
         file_remove("actions.mp4")

--- a/test/integration_tests/test_reuse.py
+++ b/test/integration_tests/test_reuse.py
@@ -16,7 +16,7 @@ import os
 import unittest
 from pathlib import Path
 from test.markers import windows_skip_marker
-from test.util import get_logical_query_plan, load_udfs_for_testing
+from test.util import get_logical_query_plan, load_udfs_for_testing, shutdown_ray
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.configuration.constants import EVA_ROOT_DIR
@@ -37,6 +37,7 @@ class ReuseTest(unittest.TestCase):
         load_udfs_for_testing()
 
     def tearDown(self):
+        shutdown_ray()
         execute_query_fetch_all("DROP TABLE IF EXISTS DETRAC;")
 
     def _verify_reuse_correctness(self, query, reuse_batch):

--- a/test/integration_tests/test_s3_load_executor.py
+++ b/test/integration_tests/test_s3_load_executor.py
@@ -15,7 +15,12 @@
 import os
 import unittest
 from pathlib import Path
-from test.util import create_dummy_batches, create_sample_video, file_remove
+from test.util import (
+    create_dummy_batches,
+    create_sample_video,
+    file_remove,
+    shutdown_ray,
+)
 
 import boto3
 import pandas as pd
@@ -28,7 +33,6 @@ from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.parser.types import FileFormatType
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_s3_load_executor.py
+++ b/test/integration_tests/test_s3_load_executor.py
@@ -28,6 +28,7 @@ from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.parser.types import FileFormatType
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -66,6 +67,8 @@ class S3LoadExecutorTest(unittest.TestCase):
             self.s3_client.upload_file(f"{video_path}/{file}", bucket_name, file)
 
     def tearDown(self):
+        shutdown_ray()
+
         file_remove("MyVideo/dummy.avi", parent_dir=self.s3_download_dir)
 
         for file in os.listdir(self.multiple_video_file_path):

--- a/test/integration_tests/test_select_executor.py
+++ b/test/integration_tests/test_select_executor.py
@@ -33,6 +33,7 @@ from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.readers.decord_reader import DecordReader
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 
@@ -55,6 +56,8 @@ class SelectExecutorTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        shutdown_ray()
+
         file_remove("dummy.avi")
         drop_query = """DROP TABLE table1;"""
         execute_query_fetch_all(drop_query)

--- a/test/integration_tests/test_select_executor.py
+++ b/test/integration_tests/test_select_executor.py
@@ -21,6 +21,7 @@ from test.util import (  # file_remove,
     file_remove,
     get_logical_query_plan,
     load_udfs_for_testing,
+    shutdown_ray,
 )
 
 import numpy as np
@@ -33,7 +34,6 @@ from eva.configuration.constants import EVA_ROOT_DIR
 from eva.models.storage.batch import Batch
 from eva.readers.decord_reader import DecordReader
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 

--- a/test/integration_tests/test_similarity.py
+++ b/test/integration_tests/test_similarity.py
@@ -23,6 +23,7 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
+from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel
@@ -94,6 +95,8 @@ class SimilarityTests(unittest.TestCase):
             base_img -= 1
 
     def tearDown(self):
+        shutdown_ray()
+
         drop_table_query = "DROP TABLE testSimilarityTable;"
         execute_query_fetch_all(drop_table_query)
         drop_table_query = "DROP TABLE testSimilarityFeatureTable;"

--- a/test/integration_tests/test_similarity.py
+++ b/test/integration_tests/test_similarity.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import create_sample_image, load_udfs_for_testing
+from test.util import create_sample_image, load_udfs_for_testing, shutdown_ray
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,6 @@ from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
-from test.util import shutdown_ray
 
 
 @pytest.mark.notparallel

--- a/test/integration_tests/test_udf_executor.py
+++ b/test/integration_tests/test_udf_executor.py
@@ -19,6 +19,7 @@ from test.util import (
     create_dummy_batches,
     create_sample_video,
     file_remove,
+    shutdown_ray,
 )
 
 import numpy as np
@@ -31,7 +32,6 @@ from eva.catalog.catalog_type import ColumnType, NdArrayType
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
-from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 

--- a/test/integration_tests/test_udf_executor.py
+++ b/test/integration_tests/test_udf_executor.py
@@ -31,6 +31,7 @@ from eva.catalog.catalog_type import ColumnType, NdArrayType
 from eva.executor.executor_utils import ExecutorError
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
+from test.util import shutdown_ray
 
 NUM_FRAMES = 10
 
@@ -52,6 +53,7 @@ class UDFExecutorTest(unittest.TestCase):
         execute_query_fetch_all(create_udf_query)
 
     def tearDown(self):
+        shutdown_ray()
         file_remove("dummy.avi")
         execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")
 

--- a/test/optimizer/rules/test_rules.py
+++ b/test/optimizer/rules/test_rules.py
@@ -23,6 +23,12 @@ from eva.catalog.catalog_type import TableType
 from eva.catalog.models.table_catalog import TableCatalogEntry
 from eva.configuration.configuration_manager import ConfigurationManager
 from eva.experimental.ray.optimizer.rules.rules import LogicalExchangeToPhysical
+from eva.experimental.ray.optimizer.rules.rules import (
+    LogicalGetToSeqScan as DistributedLogicalGetToSeqScan,
+)
+from eva.experimental.ray.optimizer.rules.rules import (
+    LogicalProjectToPhysical as DistributedLogicalProjectToPhysical,
+)
 from eva.optimizer.operators import (
     LogicalFilter,
     LogicalGet,
@@ -49,6 +55,11 @@ from eva.optimizer.rules.rules import (
     LogicalFaissIndexScanToPhysical,
     LogicalFilterToPhysical,
     LogicalFunctionScanToPhysical,
+)
+from eva.optimizer.rules.rules import (
+    LogicalGetToSeqScan as SequentialLogicalGetToSeqScan,
+)
+from eva.optimizer.rules.rules import (
     LogicalGroupByToPhysical,
     LogicalInnerJoinCommutativity,
     LogicalInsertToPhysical,
@@ -58,6 +69,11 @@ from eva.optimizer.rules.rules import (
     LogicalLimitToPhysical,
     LogicalLoadToPhysical,
     LogicalOrderByToPhysical,
+)
+from eva.optimizer.rules.rules import (
+    LogicalProjectToPhysical as SequentialLogicalProjectToPhysical,
+)
+from eva.optimizer.rules.rules import (
     LogicalRenameToPhysical,
     LogicalShowToPhysical,
     LogicalUnionToPhysical,
@@ -68,18 +84,6 @@ from eva.optimizer.rules.rules import (
     Rule,
     RuleType,
     XformLateralJoinToLinearFlow,
-)
-from eva.experimental.ray.optimizer.rules.rules import (
-    LogicalGetToSeqScan as DistributedLogicalGetToSeqScan,
-)
-from eva.experimental.ray.optimizer.rules.rules import (
-    LogicalProjectToPhysical as DistributedLogicalProjectToPhysical,
-)
-from eva.optimizer.rules.rules import (
-    LogicalGetToSeqScan as SequentialLogicalGetToSeqScan,
-)
-from eva.optimizer.rules.rules import (
-    LogicalProjectToPhysical as SequentialLogicalProjectToPhysical,
 )
 from eva.optimizer.rules.rules_manager import RulesManager
 from eva.parser.types import JoinType
@@ -207,8 +211,9 @@ class RulesTest(unittest.TestCase):
             LogicalInsertToPhysical(),
             LogicalDeleteToPhysical(),
             LogicalLoadToPhysical(),
-            DistributedLogicalGetToSeqScan() if ray_enabled else
-            SequentialLogicalGetToSeqScan(),
+            DistributedLogicalGetToSeqScan()
+            if ray_enabled
+            else SequentialLogicalGetToSeqScan(),
             LogicalDerivedGetToPhysical(),
             LogicalUnionToPhysical(),
             LogicalGroupByToPhysical(),
@@ -220,8 +225,9 @@ class RulesTest(unittest.TestCase):
             LogicalJoinToPhysicalHashJoin(),
             LogicalCreateMaterializedViewToPhysical(),
             LogicalFilterToPhysical(),
-            DistributedLogicalProjectToPhysical() if ray_enabled else
-            SequentialLogicalProjectToPhysical(),
+            DistributedLogicalProjectToPhysical()
+            if ray_enabled
+            else SequentialLogicalProjectToPhysical(),
             LogicalShowToPhysical(),
             LogicalExplainToPhysical(),
             LogicalCreateIndexToFaiss(),

--- a/test/optimizer/rules/test_rules.py
+++ b/test/optimizer/rules/test_rules.py
@@ -85,7 +85,7 @@ from eva.optimizer.rules.rules import (
     RuleType,
     XformLateralJoinToLinearFlow,
 )
-from eva.optimizer.rules.rules_manager import RulesManager
+from eva.optimizer.rules.rules_manager import RulesManager, disable_rules
 from eva.parser.types import JoinType
 from eva.server.command_handler import execute_query_fetch_all
 

--- a/test/optimizer/rules/test_rules.py
+++ b/test/optimizer/rules/test_rules.py
@@ -202,6 +202,11 @@ class RulesTest(unittest.TestCase):
 
         ray_enabled = ConfigurationManager().get_value("experimental", "ray")
 
+        # For the current version, we choose either the distributed or the
+        # sequential rule, because we do not have a logic to choose one over
+        # the other in the current optimizer. Sequential rewrite is currently
+        # embedded inside distributed rule if ray is enabled. The rule itself
+        # has some simple heuristics to choose one over the other.
         supported_implementation_rules = [
             LogicalCreateToPhysical(),
             LogicalRenameToPhysical(),

--- a/test/optimizer/test_cascade_optimizer.py
+++ b/test/optimizer/test_cascade_optimizer.py
@@ -19,13 +19,13 @@ import pandas as pd
 import pytest
 
 from eva.catalog.catalog_manager import CatalogManager
-from eva.models.storage.batch import Batch
-from eva.server.command_handler import execute_query_fetch_all
-from eva.plan_nodes.project_plan import ProjectPlan
-from eva.plan_nodes.nested_loop_join_plan import NestedLoopJoinPlan
-from eva.plan_nodes.storage_plan import StoragePlan
 from eva.experimental.ray.planner.exchange_plan import ExchangePlan
+from eva.models.storage.batch import Batch
 from eva.optimizer.plan_generator import PlanGenerator
+from eva.plan_nodes.nested_loop_join_plan import NestedLoopJoinPlan
+from eva.plan_nodes.project_plan import ProjectPlan
+from eva.plan_nodes.storage_plan import StoragePlan
+from eva.server.command_handler import execute_query_fetch_all
 
 
 @pytest.mark.notparallel

--- a/test/optimizer/test_cascade_optimizer.py
+++ b/test/optimizer/test_cascade_optimizer.py
@@ -21,6 +21,11 @@ import pytest
 from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
+from eva.plan_nodes.project_plan import ProjectPlan
+from eva.plan_nodes.nested_loop_join_plan import NestedLoopJoinPlan
+from eva.plan_nodes.storage_plan import StoragePlan
+from eva.experimental.ray.planner.exchange_plan import ExchangePlan
+from eva.optimizer.plan_generator import PlanGenerator
 
 
 @pytest.mark.notparallel
@@ -59,3 +64,49 @@ class CascadeOptimizer(unittest.TestCase):
         self.assertEqual(actual_batch, expected_batch)
 
         execute_query_fetch_all("DROP TABLE IF EXISTS MyVideo;")
+
+    def test_optimizer_post_process_strip_with_branch(self):
+        br_exch_plan_1 = ExchangePlan()
+        br_exch_plan_1.append_child(StoragePlan(None, None))
+
+        br_exch_plan_2 = ExchangePlan()
+        br_exch_plan_2.append_child(StoragePlan(None, None))
+
+        nest_plan = NestedLoopJoinPlan(None)
+        nest_plan.append_child(br_exch_plan_1)
+        nest_plan.append_child(br_exch_plan_2)
+
+        proj_plan = ProjectPlan(None)
+        proj_plan.append_child(nest_plan)
+
+        root_exch_plan = ExchangePlan()
+        root_exch_plan.append_child(proj_plan)
+
+        plan = PlanGenerator().post_process(root_exch_plan)
+
+        self.assertTrue(isinstance(plan, ProjectPlan))
+        self.assertEqual(len(plan.children), 1)
+        self.assertTrue(isinstance(plan.children[0], NestedLoopJoinPlan))
+        self.assertEqual(len(nest_plan.children), 2)
+        self.assertTrue(isinstance(nest_plan.children[0], StoragePlan))
+        self.assertTrue(isinstance(nest_plan.children[1], StoragePlan))
+
+    def test_optimizer_post_process_strip_without_branch(self):
+        child_exch_plan = ExchangePlan()
+        child_exch_plan.append_child(StoragePlan(None, None))
+
+        proj_plan = ProjectPlan(None)
+        proj_plan.append_child(child_exch_plan)
+
+        root_exch_plan = ExchangePlan()
+        root_exch_plan.append_child(proj_plan)
+
+        plan = PlanGenerator().post_process(root_exch_plan)
+
+        self.assertTrue(isinstance(plan, ExchangePlan))
+        self.assertEqual(len(plan.children), 1)
+        self.assertTrue(isinstance(plan.children[0], ProjectPlan))
+        self.assertEqual(len(proj_plan.children), 1)
+        self.assertTrue(isinstance(proj_plan.children[0], ExchangePlan))
+        self.assertEqual(len(child_exch_plan.children), 1)
+        self.assertTrue(isinstance(child_exch_plan.children[0], StoragePlan))

--- a/test/optimizer/test_cascade_optimizer.py
+++ b/test/optimizer/test_cascade_optimizer.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from test.util import NUM_FRAMES, create_sample_video, file_remove
+from test.util import NUM_FRAMES, create_sample_video, file_remove, shutdown_ray
 
 import pandas as pd
 import pytest
@@ -30,6 +30,7 @@ class CascadeOptimizer(unittest.TestCase):
         self.video_file_path = create_sample_video(NUM_FRAMES)
 
     def tearDown(self):
+        shutdown_ray()
         file_remove("dummy.avi")
 
     def test_logical_to_physical_udf(self):

--- a/test/optimizer/test_optimizer_task.py
+++ b/test/optimizer/test_optimizer_task.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 from mock import MagicMock
 
+from eva.configuration.configuration_manager import ConfigurationManager
+from eva.experimental.ray.planner.exchange_plan import ExchangePlan
 from eva.optimizer.cost_model import CostModel
 from eva.optimizer.operators import (
     LogicalFilter,
@@ -36,8 +38,6 @@ from eva.optimizer.rules.rules_manager import RulesManager
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.plan_nodes.project_plan import ProjectPlan
 from eva.plan_nodes.seq_scan_plan import SeqScanPlan
-from eva.experimental.ray.planner.exchange_plan import ExchangePlan
-from eva.configuration.configuration_manager import ConfigurationManager
 
 
 class TestOptimizerTask(unittest.TestCase):

--- a/test/optimizer/test_optimizer_task.py
+++ b/test/optimizer/test_optimizer_task.py
@@ -36,6 +36,8 @@ from eva.optimizer.rules.rules_manager import RulesManager
 from eva.plan_nodes.predicate_plan import PredicatePlan
 from eva.plan_nodes.project_plan import ProjectPlan
 from eva.plan_nodes.seq_scan_plan import SeqScanPlan
+from eva.experimental.ray.planner.exchange_plan import ExchangePlan
+from eva.configuration.configuration_manager import ConfigurationManager
 
 
 class TestOptimizerTask(unittest.TestCase):
@@ -221,12 +223,21 @@ class TestOptimizerTask(unittest.TestCase):
                 opt_cxt, root_grp_id = self.bottom_up_rewrite(root_grp_id, opt_cxt)
                 opt_cxt, root_grp_id = self.implement_group(root_grp_id, opt_cxt)
 
-                expected_expr_order = [
-                    ProjectPlan,
-                    PredicatePlan,
-                    SeqScanPlan,
-                    SeqScanPlan,
-                ]
+                if not ConfigurationManager().get_value("experimental", "ray"):
+                    expected_expr_order = [
+                        ProjectPlan,
+                        PredicatePlan,
+                        SeqScanPlan,
+                        SeqScanPlan,
+                    ]
+                else:
+                    expected_expr_order = [
+                        ExchangePlan,
+                        ProjectPlan,
+                        PredicatePlan,
+                        SeqScanPlan,
+                        SeqScanPlan,
+                    ]
                 curr_grp_id = root_grp_id
                 idx = 0
                 while True:

--- a/test/util.py
+++ b/test/util.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import os
 import socket
+import psutil
 from contextlib import closing
 from pathlib import Path
 
@@ -47,6 +48,10 @@ s3_dir_from_config = config.get_value("storage", "s3_download_dir")
 
 
 EVA_TEST_DATA_DIR = Path(config.get_value("core", "eva_installation_dir")).parent
+
+
+def is_ray_stage_running():
+    return "ray::ray_stage" in (p.name() for p in psutil.process_iter())
 
 
 def shutdown_ray():

--- a/test/util.py
+++ b/test/util.py
@@ -18,9 +18,9 @@ from contextlib import closing
 from pathlib import Path
 
 import cv2
-import ray
 import numpy as np
 import pandas as pd
+import ray
 from mock import MagicMock
 
 from eva.binder.statement_binder import StatementBinder

--- a/test/util.py
+++ b/test/util.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 import os
 import socket
-import psutil
 from contextlib import closing
 from pathlib import Path
 
 import cv2
 import numpy as np
 import pandas as pd
+import psutil
 import ray
 from mock import MagicMock
 

--- a/test/util.py
+++ b/test/util.py
@@ -48,6 +48,12 @@ s3_dir_from_config = config.get_value("storage", "s3_download_dir")
 EVA_TEST_DATA_DIR = Path(config.get_value("core", "eva_installation_dir")).parent
 
 
+def explain_query_plan(query):
+    explain_query = "EXPLAIN {}".format(query)
+    actual_batch = execute_query_fetch_all(explain_query)
+    return "\n" + actual_batch.frames.iloc[0][0]
+
+
 def prefix_worker_id(base: str):
     try:
         worker_id = os.environ["PYTEST_XDIST_WORKER"]

--- a/test/util.py
+++ b/test/util.py
@@ -59,12 +59,6 @@ def shutdown_ray():
         ray.shutdown()
 
 
-def explain_query_plan(query):
-    explain_query = "EXPLAIN {}".format(query)
-    actual_batch = execute_query_fetch_all(explain_query)
-    return "\n" + actual_batch.frames.iloc[0][0]
-
-
 def prefix_worker_id(base: str):
     try:
         worker_id = os.environ["PYTEST_XDIST_WORKER"]

--- a/test/util.py
+++ b/test/util.py
@@ -18,6 +18,7 @@ from contextlib import closing
 from pathlib import Path
 
 import cv2
+import ray
 import numpy as np
 import pandas as pd
 from mock import MagicMock
@@ -46,6 +47,11 @@ s3_dir_from_config = config.get_value("storage", "s3_download_dir")
 
 
 EVA_TEST_DATA_DIR = Path(config.get_value("core", "eva_installation_dir")).parent
+
+
+def shutdown_ray():
+    if ConfigurationManager().get_value("experimental", "ray"):
+        ray.shutdown()
 
 
 def explain_query_plan(query):


### PR DESCRIPTION
* Auto-detect availability of GPUs.
* Enable CircleCI auto-testing for Ray execution.
  * Only test CPU Ray on CircleCI.
  * Disable coverage report where it causes long hang for multi-process execution. 
* Address integration test failures for Ray. Here are a list of causes that I address in this PR.
  * Bug in Ray optimizer that does not correctly yield, which often results infinite loop in optimization step.
  * A tree-like execution plan was not previously supported for Ray, mainly because the queue population does not support that yet. For a quick merge now, I do a post-processing to disable Exchange plan for all execution plans that have branch.