### PR TITLE
fix: updates to restore build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ tutorials/*.py
 eva.txt
 prof/
 output.txt
+MagicMock/

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ VERSION = VERSION_DICT["VERSION"]
 minimal_requirement = [
     "numpy>=1.19.5,<=1.23.5",
     "opencv-python>=4.5.4.60,<4.6.0.66",  # bug in easyocr
-    "pandas>=1.1.5",
+    "pandas>=1.1.5,<2.0.0", # major changes in 2.0.0
     "Pillow>=8.4.0",
     "sqlalchemy>=1.4.0,<2.0.0", # major changes in 2.0.0
     "sqlalchemy-utils>=0.36.6",

--- a/test/integration_tests/test_reuse.py
+++ b/test/integration_tests/test_reuse.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 from pathlib import Path
+from test.markers import windows_skip_marker
 from test.util import get_logical_query_plan, load_udfs_for_testing
 
 from eva.catalog.catalog_manager import CatalogManager
@@ -115,6 +116,7 @@ class ReuseTest(unittest.TestCase):
 
         self.assertFalse(yolo_expr.has_cache())
 
+    @windows_skip_marker
     def test_reuse_after_server_shutdown(self):
         select_query = """SELECT id, label FROM DETRAC JOIN
             LATERAL YoloV5(data) AS Obj(label, bbox, conf) WHERE id < 10;"""


### PR DESCRIPTION
1. Constrained `pandas` to `2.0.0` (breaking changes)
2. Added a windows skip marker to server restart test in `test_reuse`