### PR TITLE
fix: Timeout Error

### DIFF
--- a/eva/server/server.py
+++ b/eva/server/server.py
@@ -70,7 +70,7 @@ class EvaServer:
     ):
         try:
             while True:
-                data = await asyncio.wait_for(client_reader.readline(), timeout=60.0)
+                data = await asyncio.wait_for(client_reader.readline(), timeout=None)
                 if data == b"":
                     break
 


### PR DESCRIPTION
[server.py](https://github.com/georgia-tech-db/eva/blob/0f4160692b37b6343a5e47d22e3c83aff7a15508/eva/server/server.py#L73) was set to timeout after `60.0` seconds, now changing that to `None`.

It should resolve the error where notebooks randomly fail tests