### PR TITLE
feat: Add audio sampling rate

### DIFF
--- a/eva/constants.py
+++ b/eva/constants.py
@@ -19,4 +19,5 @@ UNDEFINED_GROUP_ID = -1
 # remove this when we implement the cacheable logic in the UDF itself
 CACHEABLE_UDFS = ["YoloV5", "FaceDetector", "OCRExtractor"]
 IFRAMES = "IFRAMES"
+AUDIORATE = "AUDIORATE"
 DEFAULT_FUNCTION_EXPRESSION_COST = 100

--- a/eva/parser/eva.lark
+++ b/eva/parser/eva.lark
@@ -124,7 +124,9 @@ subquery_table_source_item: (select_statement | LR_BRACKET select_statement RR_B
     
 sample_clause: SAMPLE decimal_literal
 
-sample_clause_with_type: SAMPLE IFRAMES decimal_literal*
+sample_clause_with_type: SAMPLE sample_type decimal_literal*
+
+sample_type: IFRAMES | AUDIORATE
 
 join_part: JOIN table_source_item_with_sample (ON expression | USING LR_BRACKET uid_list RR_BRACKET)?  ->inner_join
          | JOIN LATERAL table_valued_function alias_clause? ->lateral_join
@@ -348,6 +350,7 @@ REFERENCES:                          "REFERENCES"
 RENAME:                              "RENAME"
 SAMPLE:                              "SAMPLE"
 IFRAMES:                             "IFRAMES"
+AUDIORATE:                           "AUDIORATE"
 SELECT:                             "SELECT"
 SET:                                 "SET"
 SHUTDOWN:                            "SHUTDOWN"

--- a/eva/readers/decord_reader.py
+++ b/eva/readers/decord_reader.py
@@ -17,7 +17,7 @@ from typing import Dict, Iterator
 import numpy as np
 
 from eva.catalog.catalog_type import VideoColumnName
-from eva.constants import IFRAMES
+from eva.constants import AUDIORATE, IFRAMES
 from eva.expression.abstract_expression import AbstractExpression
 from eva.expression.expression_utils import extract_range_list_from_predicate
 from eva.readers.abstract_reader import AbstractReader
@@ -80,7 +80,6 @@ class DecordReader(AbstractReader):
         logger.debug("Reading frames")
 
         if self._sampling_type == IFRAMES:
-            assert not self._read_audio, "Cannot use IFRAMES with audio streams"
             iframes = self._reader.get_key_indices()
             idx = 0
             for begin, end in range_list:
@@ -92,7 +91,7 @@ class DecordReader(AbstractReader):
                     idx += self._sampling_rate
                     yield self._get_frame(frame_id)
 
-        elif self._sampling_rate == 1:
+        elif self._sampling_rate == 1 or self._read_audio:
             for begin, end in range_list:
                 frame_id = begin
                 while frame_id <= end:
@@ -109,14 +108,23 @@ class DecordReader(AbstractReader):
     def initialize_reader(self):
         decord = _lazy_import_decord()
         if self._read_audio:
+            assert (
+                self._sampling_type != IFRAMES
+            ), "Cannot use IFRAMES with audio streams"
+            sample_rate = 16000
+            if self._sampling_type == AUDIORATE and self._sampling_rate != 1:
+                sample_rate = self._sampling_rate
             try:
                 self._reader = decord.AVReader(
-                    self.file_url, mono=True, sample_rate=16000
+                    self.file_url, mono=True, sample_rate=sample_rate
                 )
                 self._get_frame = self.__get_audio_frame
             except decord._ffi.base.DECORDError as error_msg:
                 assert "Can't find audio stream" not in str(error_msg), error_msg
         else:
+            assert (
+                self._sampling_type != AUDIORATE
+            ), "Cannot use AUDIORATE with video streams"
             self._reader = decord.VideoReader(self.file_url)
             self._get_frame = self.__get_video_frame
 

--- a/test/readers/test_decord_reader.py
+++ b/test/readers/test_decord_reader.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 
 from eva.configuration.constants import EVA_ROOT_DIR
-from eva.constants import IFRAMES
+from eva.constants import AUDIORATE, IFRAMES
 from eva.expression.abstract_expression import ExpressionType
 from eva.expression.comparison_expression import ComparisonExpression
 from eva.expression.constant_value_expression import ConstantValueExpression
@@ -164,32 +164,55 @@ class DecordLoaderTest(unittest.TestCase):
             self.assertIn("Can't find audio stream", e.args[0].args[0])
 
     def test_should_throw_error_when_sampling_iframes_for_audio(self):
-        video_loader = DecordReader(
-            file_url=self.video_with_audio_file_url,
-            sampling_type=IFRAMES,
-            read_audio=True,
-            read_video=False,
-        )
         try:
+            video_loader = DecordReader(
+                file_url=self.video_with_audio_file_url,
+                sampling_type=IFRAMES,
+                read_audio=True,
+                read_video=False,
+            )
             list(video_loader.read())
             self.fail("Didn't raise AssertionError")
         except AssertionError as e:
             self.assertEquals("Cannot use IFRAMES with audio streams", e.args[0])
 
+    def test_should_throw_error_when_sampling_audio_for_video(self):
+        try:
+            video_loader = DecordReader(
+                file_url=self.video_file_url,
+                sampling_type=AUDIORATE,
+                read_audio=False,
+                read_video=True,
+            )
+            list(video_loader.read())
+            self.fail("Didn't raise AssertionError")
+        except AssertionError as e:
+            self.assertEquals("Cannot use AUDIORATE with video streams", e.args[0])
+
     def test_should_return_audio_frames(self):
-        # running test with sampling rate so that fewer frames are
-        # returned and verified, this helps keep the stored frame data size small
         video_loader = DecordReader(
             file_url=self.video_with_audio_file_url,
-            sampling_rate=100,
+            sampling_type=AUDIORATE,
+            sampling_rate=16000,
             read_audio=True,
             read_video=False,
         )
         batches = list(video_loader.read())
+        # running test on select frame ids so that fewer frames are
+        # returned and verified, this helps keep the stored frame data size small
+        batches = (
+            batches[0]
+            .frames[
+                batches[0].frames.index.isin(
+                    [0, 100, 200, 300, 400, 500, 600, 700, 800, 900]
+                )
+            ]
+            .reset_index()
+        )
 
         for i, frame in enumerate(self.audio_frames):
             self.assertTrue(
-                np.array_equiv(self.audio_frames[i], batches[0].frames.iloc[i]["audio"])
+                np.array_equiv(self.audio_frames[i], batches.iloc[i]["audio"])
             )
         # verify that no video frame was read
-        self.assertEqual(batches[0].frames.loc[0]["data"].shape, (0,))
+        self.assertEqual(batches.iloc[0]["data"].shape, (0,))

--- a/test/readers/test_decord_reader.py
+++ b/test/readers/test_decord_reader.py
@@ -152,19 +152,19 @@ class DecordLoaderTest(unittest.TestCase):
             self.assertEqual(batches, expected)
 
     def test_should_throw_error_for_audioless_video(self):
-        try:
+        with self.assertRaises(AssertionError) as error_context:
             video_loader = DecordReader(
                 file_url=self.video_file_url,
                 read_audio=True,
                 read_video=True,
             )
             list(video_loader.read())
-            self.fail("Didn't raise AssertionError")
-        except AssertionError as e:
-            self.assertIn("Can't find audio stream", e.args[0].args[0])
+        self.assertIn(
+            "Can't find audio stream", error_context.exception.args[0].args[0]
+        )
 
     def test_should_throw_error_when_sampling_iframes_for_audio(self):
-        try:
+        with self.assertRaises(AssertionError) as error_context:
             video_loader = DecordReader(
                 file_url=self.video_with_audio_file_url,
                 sampling_type=IFRAMES,
@@ -172,12 +172,12 @@ class DecordLoaderTest(unittest.TestCase):
                 read_video=False,
             )
             list(video_loader.read())
-            self.fail("Didn't raise AssertionError")
-        except AssertionError as e:
-            self.assertEquals("Cannot use IFRAMES with audio streams", e.args[0])
+        self.assertEquals(
+            "Cannot use IFRAMES with audio streams", error_context.exception.args[0]
+        )
 
     def test_should_throw_error_when_sampling_audio_for_video(self):
-        try:
+        with self.assertRaises(AssertionError) as error_context:
             video_loader = DecordReader(
                 file_url=self.video_file_url,
                 sampling_type=AUDIORATE,
@@ -185,9 +185,9 @@ class DecordLoaderTest(unittest.TestCase):
                 read_video=True,
             )
             list(video_loader.read())
-            self.fail("Didn't raise AssertionError")
-        except AssertionError as e:
-            self.assertEquals("Cannot use AUDIORATE with video streams", e.args[0])
+        self.assertEquals(
+            "Cannot use AUDIORATE with video streams", error_context.exception.args[0]
+        )
 
     def test_should_return_audio_frames(self):
         video_loader = DecordReader(


### PR DESCRIPTION
This feature allows the users to specify the audio sampling rate like so:

`SELECT UDF(audio,..) FROM VIDEOS SAMPLE AUDIORATE 22500`

If no sampling rate is given, we default to 16000