### PR TITLE
test: xdist fix errors due to /.eva directory form a previous run

### DIFF
--- a/eva/configuration/bootstrap_environment.py
+++ b/eva/configuration/bootstrap_environment.py
@@ -64,11 +64,20 @@ def bootstrap_environment(eva_config_dir: Path, eva_installation_dir: Path):
     s3_dir = eva_config_dir / S3_DOWNLOAD_DIR
     tmp_dir = eva_config_dir / TMP_DIR
 
-    eva_config_dir.mkdir(parents=True, exist_ok=True)
-    index_dir.mkdir(parents=True, exist_ok=True)
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    s3_dir.mkdir(parents=True, exist_ok=True)
-    tmp_dir.mkdir(parents=True, exist_ok=True)
+    if not eva_config_dir.exists():
+        eva_config_dir.mkdir(parents=True, exist_ok=True)
+    
+    if not index_dir.exists():
+        index_dir.mkdir(parents=True, exist_ok=True)
+    
+    if not cache_dir.exists():
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    
+    if not s3_dir.exists():
+        s3_dir.mkdir(parents=True, exist_ok=True)
+    
+    if not tmp_dir.exists():
+        tmp_dir.mkdir(parents=True, exist_ok=True)
 
     # copy eva.yml into config path
     if not config_file_path.exists():

--- a/eva/configuration/configuration_manager.py
+++ b/eva/configuration/configuration_manager.py
@@ -47,21 +47,21 @@ class ConfigurationManager(object):
 
     @classmethod
     def _create_if_not_exists(cls):
-        if not cls._yml_path.exists():
-            initial_eva_config_dir = Path(EVA_DEFAULT_DIR)
+        # if not cls._yml_path.exists():
+        initial_eva_config_dir = Path(EVA_DEFAULT_DIR)
 
-            # parallelize tests using pytest-xdist
-            # activated only under pytest-xdist
-            # Changes config dir From EVA_DEFAULT_DIR To EVA_DEFAULT_DIR / gw1
-            # (where gw1 is worker id)
-            updated_eva_config_dir = cls.suffix_pytest_xdist_worker_id_to_dir(
-                initial_eva_config_dir
-            )
-            cls._yml_path = updated_eva_config_dir / EVA_CONFIG_FILE
-            bootstrap_environment(
-                eva_config_dir=updated_eva_config_dir,
-                eva_installation_dir=EVA_INSTALLATION_DIR,
-            )
+        # parallelize tests using pytest-xdist
+        # activated only under pytest-xdist
+        # Changes config dir From EVA_DEFAULT_DIR To EVA_DEFAULT_DIR / gw1
+        # (where gw1 is worker id)
+        updated_eva_config_dir = cls.suffix_pytest_xdist_worker_id_to_dir(
+            initial_eva_config_dir
+        )
+        cls._yml_path = updated_eva_config_dir / EVA_CONFIG_FILE
+        bootstrap_environment(
+            eva_config_dir=updated_eva_config_dir,
+            eva_installation_dir=EVA_INSTALLATION_DIR,
+        )
 
     @classmethod
     def _get(cls, category: str, key: str) -> Any:


### PR DESCRIPTION
While using pytest-xdist to parallelize tests, config_dir needs to be updated from EVA_DEFAULT_DIR To EVA_DEFAULT_DIR / gw1 (where gw1 is worker_id) always 