### PR TITLE
fix: cache indices after filtering

### DIFF
--- a/eva/expression/function_expression.py
+++ b/eva/expression/function_expression.py
@@ -208,7 +208,7 @@ class FunctionExpression(AbstractExpression):
             assert len(cache_keys) == len(batch), "Not all rows have the cache key"
 
         cache_miss = np.full(len(batch), True)
-        for idx, key in cache_keys.iterrows():
+        for idx, (_, key) in enumerate(cache_keys.iterrows()):
             val = self._cache.store.get(key.to_numpy())
             results[idx] = val
             cache_miss[idx] = val is None


### PR DESCRIPTION
Index is wrong after running some predicates. We should use actual index during iteration. Illustrate using an example
```
     col
0    a
1    b
2    c

After running some predicates, two rows may be filtered
     col
2    c
```

We may add a test case here. 