### PR TITLE
fix: similarity test

### DIFF
--- a/eva/catalog/models/column_catalog.py
+++ b/eva/catalog/models/column_catalog.py
@@ -66,6 +66,13 @@ class ColumnCatalog(BaseModel):
         cascade="all, delete",
     )
 
+    # Column that index is built on.
+    _index_column = relationship(
+        "IndexCatalog",
+        back_populates="_feat_column",
+        cascade="all, delete"
+    )
+
     def __init__(
         self,
         name: str,

--- a/eva/catalog/models/column_catalog.py
+++ b/eva/catalog/models/column_catalog.py
@@ -68,9 +68,7 @@ class ColumnCatalog(BaseModel):
 
     # Column that index is built on.
     _index_column = relationship(
-        "IndexCatalog",
-        back_populates="_feat_column",
-        cascade="all, delete"
+        "IndexCatalog", back_populates="_feat_column", cascade="all, delete"
     )
 
     def __init__(

--- a/eva/catalog/models/index_catalog.py
+++ b/eva/catalog/models/index_catalog.py
@@ -39,10 +39,13 @@ class IndexCatalog(BaseModel):
     _name = Column("name", String(100), unique=True)
     _save_file_path = Column("save_file_path", String(128))
     _type = Column("type", Enum(IndexType), default=Enum)
-    _feat_column_id = Column("column_id", Integer, ForeignKey("column_catalog._row_id"))
+    _feat_column_id = Column("column_id", Integer, ForeignKey("column_catalog._row_id", ondelete="CASCADE"))
     _udf_signature = Column("udf", String, default=None)
 
-    _feat_column = relationship("ColumnCatalog")
+    _feat_column = relationship(
+        "ColumnCatalog",
+        back_populates="_index_column",
+    )
 
     def __init__(
         self,

--- a/eva/catalog/models/index_catalog.py
+++ b/eva/catalog/models/index_catalog.py
@@ -39,7 +39,9 @@ class IndexCatalog(BaseModel):
     _name = Column("name", String(100), unique=True)
     _save_file_path = Column("save_file_path", String(128))
     _type = Column("type", Enum(IndexType), default=Enum)
-    _feat_column_id = Column("column_id", Integer, ForeignKey("column_catalog._row_id", ondelete="CASCADE"))
+    _feat_column_id = Column(
+        "column_id", Integer, ForeignKey("column_catalog._row_id", ondelete="CASCADE")
+    )
     _udf_signature = Column("udf", String, default=None)
 
     _feat_column = relationship(

--- a/eva/executor/create_index_executor.py
+++ b/eva/executor/create_index_executor.py
@@ -98,7 +98,7 @@ class CreateIndexExecutor(AbstractExecutor):
             index = None
             input_dim = -1
             storage_engine = StorageEngine.factory(feat_catalog_entry)
-            for input_batch in storage_engine.read(feat_catalog_entry, 1):
+            for input_batch in storage_engine.read(feat_catalog_entry):
                 if udf_func:
                     # Create index through UDF expression.
                     # UDF(input column) -> 2 dimension feature vector.

--- a/test/integration_tests/test_similarity.py
+++ b/test/integration_tests/test_similarity.py
@@ -12,20 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import unittest
 from test.util import create_sample_image, load_udfs_for_testing, shutdown_ray
 
+import cv2
 import numpy as np
 import pandas as pd
 import pytest
-import cv2
-import os
 
 from eva.catalog.catalog_manager import CatalogManager
+from eva.configuration.configuration_manager import ConfigurationManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
-from eva.configuration.configuration_manager import ConfigurationManager
 
 
 @pytest.mark.notparallel
@@ -96,11 +96,11 @@ class SimilarityTests(unittest.TestCase):
             )
 
             # Create an actual image dataset.
-            img_save_path = os.path.join(ConfigurationManager().get_value("storage", "tmp_dir"), f"test_similar_img{i}.jpg") 
-            cv2.imwrite(
-                img_save_path,
-                base_img
+            img_save_path = os.path.join(
+                ConfigurationManager().get_value("storage", "tmp_dir"),
+                f"test_similar_img{i}.jpg",
             )
+            cv2.imwrite(img_save_path, base_img)
             load_image_query = (
                 f"LOAD IMAGE '{img_save_path}' INTO testSimilarityImageDataset;"
             )

--- a/test/integration_tests/test_similarity.py
+++ b/test/integration_tests/test_similarity.py
@@ -94,7 +94,9 @@ class SimilarityTests(unittest.TestCase):
             base_img -= 1
 
         # Create an actual image dataset.
-        load_image_query = f"LOAD IMAGE '{self.img_path}' INTO testSimilarityImageDataset;"
+        load_image_query = (
+            f"LOAD IMAGE '{self.img_path}' INTO testSimilarityImageDataset;"
+        )
         execute_query_fetch_all(load_image_query)
 
     def tearDown(self):

--- a/test/integration_tests/test_similarity.py
+++ b/test/integration_tests/test_similarity.py
@@ -18,11 +18,14 @@ from test.util import create_sample_image, load_udfs_for_testing, shutdown_ray
 import numpy as np
 import pandas as pd
 import pytest
+import cv2
+import os
 
 from eva.catalog.catalog_manager import CatalogManager
 from eva.models.storage.batch import Batch
 from eva.server.command_handler import execute_query_fetch_all
 from eva.storage.storage_engine import StorageEngine
+from eva.configuration.configuration_manager import ConfigurationManager
 
 
 @pytest.mark.notparallel
@@ -91,13 +94,19 @@ class SimilarityTests(unittest.TestCase):
                     )
                 ),
             )
-            base_img -= 1
 
-        # Create an actual image dataset.
-        load_image_query = (
-            f"LOAD IMAGE '{self.img_path}' INTO testSimilarityImageDataset;"
-        )
-        execute_query_fetch_all(load_image_query)
+            # Create an actual image dataset.
+            img_save_path = os.path.join(ConfigurationManager().get_value("storage", "tmp_dir"), f"test_similar_img{i}.jpg") 
+            cv2.imwrite(
+                img_save_path,
+                base_img
+            )
+            load_image_query = (
+                f"LOAD IMAGE '{img_save_path}' INTO testSimilarityImageDataset;"
+            )
+            execute_query_fetch_all(load_image_query)
+
+            base_img -= 1
 
     def tearDown(self):
         shutdown_ray()
@@ -302,9 +311,10 @@ class SimilarityTests(unittest.TestCase):
                                     ON testSimilarityImageDataset (DummyFeatureExtractor(data))
                                     USING HNSW;"""
         execute_query_fetch_all(create_index_query)
-        select_query = """SELECT data FROM testSimilarityImageDataset
+        select_query = """SELECT _row_id FROM testSimilarityImageDataset
                             ORDER BY Similarity(DummyFeatureExtractor(Open("{}")), DummyFeatureExtractor(data))
                             LIMIT 1;""".format(
             self.img_path
         )
-        execute_query_fetch_all(select_query)
+        res_batch = execute_query_fetch_all(select_query)
+        self.assertEqual(res_batch.frames["testsimilarityimagedataset._row_id"][0], 5)


### PR DESCRIPTION
* Foreign key is not correctly configured, which prevents dataset tables to be dropped.
* Storage read gets extra argument after storage engine change.
* Add test case just to make sure index creation and similarity search runs correctly. 
