### PR TITLE
feat: Ray redesign

### DIFF
--- a/eva/eva.yml
+++ b/eva/eva.yml
@@ -23,11 +23,13 @@ storage:
   image_engine: "eva.storage.image_storage_engine.ImageStorageEngine"
 server:
   host: "0.0.0.0"
-  port: 5432
+  port: 7213
   socket_timeout: 60
 
 experimental:
   ray: False
+  ray_predicate: True
+  ray_parallelism: 8
 
 third_party:
   openai_api_key: ""

--- a/eva/eva.yml
+++ b/eva/eva.yml
@@ -23,13 +23,13 @@ storage:
   image_engine: "eva.storage.image_storage_engine.ImageStorageEngine"
 server:
   host: "0.0.0.0"
-  port: 7213
+  port: 5432
   socket_timeout: 60
 
 experimental:
   ray: False
-  ray_predicate: True
-  ray_parallelism: 8
+  ray_predicate: False
+  ray_parallelism: 16
 
 third_party:
   openai_api_key: ""

--- a/eva/executor/executor_utils.py
+++ b/eva/executor/executor_utils.py
@@ -21,7 +21,6 @@ from typing import Generator, List
 import cv2
 
 from eva.catalog.catalog_manager import CatalogManager
-from eva.configuration.configuration_manager import ConfigurationManager
 from eva.executor.execution_context import Context
 from eva.expression.abstract_expression import AbstractExpression
 from eva.models.storage.batch import Batch

--- a/eva/executor/predicate_executor.py
+++ b/eva/executor/predicate_executor.py
@@ -14,11 +14,26 @@
 # limitations under the License.
 from typing import Iterator
 
+from eva.configuration.configuration_manager import ConfigurationManager
 from eva.executor.abstract_executor import AbstractExecutor
-from eva.executor.executor_utils import apply_predicate
+from eva.executor.executor_utils import apply_predicate, apply_predicate_distributed
 from eva.models.storage.batch import Batch
 from eva.plan_nodes.predicate_plan import PredicatePlan
+from itertools import islice
 
+def batched(iterable, n):
+    """    
+    Batch data into tuples of length n. The last batch may be shorter.
+    e.g. batched('ABCDEFG', 3) --> ABC DEF G
+
+    Note: This is copied from the implementation of itertools.batched available from python3.12 onwards
+    """
+    
+    if n < 1:
+        raise ValueError('n must be at least one')
+    it = iter(iterable)
+    while batch := list(islice(it, n)):
+        yield batch
 
 class PredicateExecutor(AbstractExecutor):
     """ """
@@ -29,7 +44,19 @@ class PredicateExecutor(AbstractExecutor):
 
     def exec(self, *args, **kwargs) -> Iterator[Batch]:
         child_executor = self.children[0]
-        for batch in child_executor.exec(**kwargs):
-            batch = apply_predicate(batch, self.predicate)
-            if not batch.empty():
-                yield batch
+        ray_enabled = ConfigurationManager().get_value("experimental", "ray_predicate")
+        batches = child_executor.exec(**kwargs)
+        if (ray_enabled):
+            ray_parallelism = ConfigurationManager().get_value("experimental", "ray_parallelism")
+            for batch_list in batched(batches, ray_parallelism):
+                output_batches = apply_predicate_distributed(batch_list, self.predicate, ray_parallelism)
+                for op_batch in output_batches:
+                    if not op_batch.empty():
+                        yield op_batch
+        else:
+            for batch in batches:
+                batch = apply_predicate(batch, self.predicate)
+                if not batch.empty():
+                    yield batch
+
+            

--- a/eva/server/server.py
+++ b/eva/server/server.py
@@ -45,6 +45,7 @@ class EvaServer:
         async with self._server:
             await self._server.serve_forever()
 
+        ray.shutdown()
         logger.info("Successfully shutdown server")
 
     async def stop_eva_server(self):

--- a/eva/server/server.py
+++ b/eva/server/server.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import ray
 import string
 from asyncio import StreamReader, StreamWriter
 
 from eva.server.command_handler import handle_request
 from eva.utils.logging_manager import logger
 
-
+ray.init(num_cpus=8, num_gpus=8)
 class EvaServer:
     """
     Receives messages and offloads them to another task for processing them.


### PR DESCRIPTION
EVA on Ray is currently unstable because we use Exchanges. The current design has the following limitations:

Introduction of exchange operator is hard-coded
Splits in plans cannot be handled by exchanges
Exchanges are not context free, as a top-level exchange depends on lower exchanges
Although there can be a lot of operators in between two exchanges that are run on Ray, only UDFs benefit
Costing is not easy
This PR removes the use of Exchange operator and localizes the use of ray to only FunctionExpressions. This has the following advantages:

The above problems are eliminated as we no longer need an Exchange operator as ray is just used as a distributed execution alternative for FunctionExpression
Use of Ray is localized only to FunctionExpressions
We cost FunctionExpressions, and can use this information to guide heuristics for ray
Todo:
[] Analysis (preliminary analysis showed 25% improvement of running FastRCNNObjectDetector on UADETRAC when increasing parallelism from 2 to 16)
[] Code cleanup
[] Tests