### PR TITLE
fix: restart eva_server process for every tutorial

### DIFF
--- a/tutorials/00-start-eva-server.ipynb
+++ b/tutorials/00-start-eva-server.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,6 +27,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -86,7 +89,7 @@
     "def stop_eva_server():\n",
     "    for proc in process_iter():\n",
     "        if is_eva_server_process(proc):\n",
-    "            print(\"Stop eva_server\")\n",
+    "            print(\"Stopping EVA Server ...\")\n",
     "            proc.send_signal(SIGTERM)\n",
     "\n",
     "def is_eva_server_running():\n",
@@ -99,7 +102,7 @@
     "    os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
     "\n",
     "    # Start EVA server\n",
-    "    print(\"Run eva_server ... ...\")\n",
+    "    print(\"Starting EVA Server ...\")\n",
     "    shell(\"nohup eva_server > eva.log 2>&1 &\")\n",
     "\n",
     "    last_few_lines_count = 3\n",
@@ -148,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/00-start-eva-server.ipynb
+++ b/tutorials/00-start-eva-server.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -61,12 +58,26 @@
     "## Install EVA package if needed\n",
     "%pip install \"evadb\" --quiet\n",
     "\n",
+    "import re\n",
     "import os\n",
     "import time\n",
+    "import platform\n",
+    "import itertools\n",
+    "\n",
     "from psutil import process_iter\n",
     "from signal import SIGTERM\n",
-    "import re\n",
-    "import itertools\n",
+    "\n",
+    "\n",
+    "def is_eva_server_process(proc):\n",
+    "    if platform.system() == \"Darwin\":\n",
+    "        if proc.name() == \"Python\":\n",
+    "            cmdline = proc.cmdline()\n",
+    "            return len(cmdline) > 1 and \"eva_server\" in cmdline[1]\n",
+    "    elif platform.system() == \"Linux\":\n",
+    "        return proc.name() == \"eva_server\"\n",
+    "    \n",
+    "    # TODO: Handle for Windows\n",
+    "    return False\n",
     "\n",
     "def shell(command):\n",
     "    print(command)\n",
@@ -74,22 +85,21 @@
     "\n",
     "def stop_eva_server():\n",
     "    for proc in process_iter():\n",
-    "        if proc.name() == \"eva_server\":\n",
+    "        if is_eva_server_process(proc):\n",
+    "            print(\"Stop eva_server\")\n",
     "            proc.send_signal(SIGTERM)\n",
     "\n",
     "def is_eva_server_running():\n",
     "    for proc in process_iter():\n",
-    "        if proc.name() == \"eva_server\":\n",
+    "        if is_eva_server_process(proc):\n",
     "            return True\n",
     "    return False\n",
     "\n",
     "def launch_eva_server():\n",
-    "    # Stop EVA server if it is running\n",
-    "    # stop_eva_server()\n",
-    "\n",
-    "    os.environ['GPU_DEVICES'] = '0'\n",
+    "    os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
     "\n",
     "    # Start EVA server\n",
+    "    print(\"Run eva_server ... ...\")\n",
     "    shell(\"nohup eva_server > eva.log 2>&1 &\")\n",
     "\n",
     "    last_few_lines_count = 3\n",
@@ -109,23 +119,22 @@
     "    nest_asyncio.apply()\n",
     "\n",
     "    status = is_eva_server_running()\n",
-    "    if status == False:\n",
-    "        launch_eva_server()\n",
+    "    if status:\n",
+    "        stop_eva_server()\n",
+    "    \n",
+    "    launch_eva_server()\n",
     "\n",
     "    # Connect client with server\n",
-    "    connection = connect(host = '127.0.0.1', port = 8803) \n",
+    "    connection = connect(host=\"127.0.0.1\", port=8803) \n",
     "    cursor = connection.cursor()\n",
     "\n",
-    "    return cursor\n",
-    "\n",
-    "# Launch server\n",
-    "launch_eva_server()"
+    "    return cursor"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.10 ('test_evadb': venv)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -139,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Currently, eva_server is not restarted when running a tutorial. In this case, if ~/.eva directory is deleted or modified by user, the eva_server process enters a not clean state. 