### PR TITLE
feat: create materialized view infers column name

### DIFF
--- a/eva/parser/eva.lark
+++ b/eva/parser/eva.lark
@@ -30,7 +30,7 @@ rename_table: RENAME TABLE table_name TO table_name
 create_udf: CREATE UDF if_not_exists? udf_name INPUT create_definitions OUTPUT create_definitions TYPE udf_type IMPL udf_impl udf_metadata* | CREATE UDF if_not_exists? udf_name IMPL udf_impl udf_metadata* | CREATE UDF if_not_exists? udf_name TYPE udf_type udf_metadata*
 
 // Create Materialized View
-create_materialized_view: CREATE MATERIALIZED VIEW if_not_exists? table_name ("(" uid_list ")") AS select_statement 
+create_materialized_view: CREATE MATERIALIZED VIEW if_not_exists? table_name ("(" uid_list ")") AS select_statement | CREATE MATERIALIZED VIEW if_not_exists? table_name AS select_statement
 
 // Details
 udf_name: uid

--- a/eva/parser/lark_visitor/_create_statements.py
+++ b/eva/parser/lark_visitor/_create_statements.py
@@ -234,6 +234,7 @@ class CreateTable:
         view_info = None
         if_not_exists = False
         query = None
+        uid_list = []
 
         for child in tree.children:
             if isinstance(child, Tree):
@@ -248,9 +249,17 @@ class CreateTable:
 
         # setting all other column definition attributes as None,
         # need to figure from query
-        col_list = [
-            ColumnDefinition(uid.col_name, None, None, None) for uid in uid_list
-        ]
+        if uid_list == []:
+            assert (query is not None)
+            for uid in query.target_list:
+                uid_list.append(uid)
+
+        col_list = []
+        for uid in uid_list:
+            if hasattr(uid, "col_name"):
+                col_list.append(ColumnDefinition(uid.col_name, None, None, None))
+            elif hasattr(uid, "output"):
+                col_list.append(ColumnDefinition(uid.output, None, None, None))
         return CreateMaterializedViewStatement(
             view_info, col_list, if_not_exists, query
         )


### PR DESCRIPTION
Per issue #739 
Create materialized view is able infer column names. Column name is therefore optional on the user end.

Before:
CREATE MATERIALIZED VIEW dummy_view **(id, label)** AS SELECT id, DummyObjectDetector(data).label FROM MyVideo;

After:
CREATE MATERIALIZED VIEW dummy_view AS SELECT id, DummyObjectDetector(data).label FROM MyVideo;