### PR TITLE
refactor: Create .git-blame-ignore-revs 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Formatted license 
+ebef40e5931de68dabc4f6d25df4b691b1468042


### PR DESCRIPTION
Most python files were modified with ebef40e5931de68dabc4f6d25df4b691b1468042. This PR lets us ignore ebef40e5931de68dabc4f6d25df4b691b1468042 while viewing blame.

For more information about the .git-blame-ignore-revs file, see [Ignore Commits in the Blame View](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view).