### PR TITLE
docs: bump python for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,29 +1,26 @@
 # .readthedocs.yaml
-# # Read the Docs configuration file
-# # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 #
-# # Required
+# Required
 version: 2
 #
 # # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
     tools:
-        python: "3.10"
-            # You can also specify other tool versions:
-                # nodejs: "19"
-                    # rust: "1.64"
-                        # golang: "1.19"
+      python: "3.10"
+            
 
-                        # Build documentation in the docs/ directory with Sphinx
-                        sphinx:
-                           configuration: docs/conf.py
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
 
-                           # If using Sphinx, optionally build your docs in additional formats such as PDF
-                           # formats:
-                           #    - pdf
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
 
-                           # Optionally declare the Python requirements required to build your docs
-                           python:
-                              install:
-                                 - requirements: docs/requirements.txt
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# # Read the Docs configuration file
+# # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+#
+# # Required
+version: 2
+#
+# # Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+    tools:
+        python: "3.11"
+            # You can also specify other tool versions:
+                # nodejs: "19"
+                    # rust: "1.64"
+                        # golang: "1.19"
+
+                        # Build documentation in the docs/ directory with Sphinx
+                        sphinx:
+                           configuration: docs/conf.py
+
+                           # If using Sphinx, optionally build your docs in additional formats such as PDF
+                           # formats:
+                           #    - pdf
+
+                           # Optionally declare the Python requirements required to build your docs
+                           python:
+                              install:
+                                 - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,8 @@ version: 2
 # # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
-    tools:
-      python: "3.10"
+  tools:
+    python: "3.10"
             
 
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
     tools:
-        python: "3.11"
+        python: "3.10"
             # You can also specify other tool versions:
                 # nodejs: "19"
                     # rust: "1.64"


### PR DESCRIPTION
Build fails on `python 3.7`. Moving docs to `python 3.10` .
Reference: https://docs.readthedocs.io/en/stable/config-file/v2.html
