### PR TITLE
fix: GPU ids and degree of parallelism

### DIFF
--- a/evadb/executor/execution_context.py
+++ b/evadb/executor/execution_context.py
@@ -39,6 +39,7 @@ class Context:
 
     @property
     def gpus(self):
+        print("GPU Devices", self._gpus)
         return self._gpus
 
     def _populate_gpu_from_config(self) -> List:

--- a/evadb/executor/execution_context.py
+++ b/evadb/executor/execution_context.py
@@ -39,7 +39,6 @@ class Context:
 
     @property
     def gpus(self):
-        print("GPU Devices", self._gpus)
         return self._gpus
 
     def _populate_gpu_from_config(self) -> List:

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -1220,6 +1220,20 @@ class LogicalVectorIndexScanToPhysical(Rule):
         yield after
 
 
+"""
+Rules to optimize Ray.
+"""
+
+
+def get_ray_env_dict():
+    # Get the highest GPU id and expose all GPUs that have id lower than
+    # the max id.
+    max_gpu_id = max(Context().gpus) + 1
+    return {
+        "CUDA_VISIBLE_DEVICES": ",".join([str(n) for n in range(max_gpu_id)])
+    }
+
+
 class LogicalExchangeToPhysical(Rule):
     def __init__(self):
         pattern = Pattern(OperatorType.LOGICALEXCHANGE)
@@ -1254,15 +1268,15 @@ class LogicalApplyAndMergeToRayPhysical(Rule):
     def apply(self, before: LogicalApplyAndMerge, context: OptimizerContext):
         apply_plan = ApplyAndMergePlan(before.func_expr, before.alias, before.do_unnest)
 
-        parallelism = 2 if len(Context().gpus) > 1 else 1
-        ray_parallel_env_conf_dict = [
-            {"CUDA_VISIBLE_DEVICES": str(i)} for i in range(parallelism)
-        ]
+        parallelism = 2
+
+        ray_process_env_dict = get_ray_env_dict()
+        ray_parallel_env_conf_dict = [ray_process_env_dict for _ in range(parallelism)]
 
         exchange_plan = ExchangePlan(
             inner_plan=apply_plan,
             parallelism=parallelism,
-            ray_pull_env_conf_dict={"CUDA_VISIBLE_DEVICES": "0"},
+            ray_pull_env_conf_dict=ray_process_env_dict,
             ray_parallel_env_conf_dict=ray_parallel_env_conf_dict,
         )
         for child in before.children:
@@ -1293,15 +1307,15 @@ class LogicalProjectToRayPhysical(Rule):
                 project_plan.append_child(child)
             yield project_plan
         else:
-            parallelism = 2 if len(Context().gpus) > 1 else 1
-            ray_parallel_env_conf_dict = [
-                {"CUDA_VISIBLE_DEVICES": str(i)} for i in range(parallelism)
-            ]
+            parallelism = 2
+
+            ray_process_env_dict = get_ray_env_dict()
+            ray_parallel_env_conf_dict = [ray_process_env_dict for _ in range(parallelism)]
 
             exchange_plan = ExchangePlan(
                 inner_plan=project_plan,
                 parallelism=parallelism,
-                ray_pull_env_conf_dict={"CUDA_VISIBLE_DEVICES": "0"},
+                ray_pull_env_conf_dict=ray_process_env_dict,
                 ray_parallel_env_conf_dict=ray_parallel_env_conf_dict,
             )
             for child in before.children:

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -1228,8 +1228,11 @@ Rules to optimize Ray.
 def get_ray_env_dict():
     # Get the highest GPU id and expose all GPUs that have id lower than
     # the max id.
-    max_gpu_id = max(Context().gpus) + 1
-    return {"CUDA_VISIBLE_DEVICES": ",".join([str(n) for n in range(max_gpu_id)])}
+    if len(Context().gpus) > 0:
+        max_gpu_id = max(Context().gpus) + 1
+        return {"CUDA_VISIBLE_DEVICES": ",".join([str(n) for n in range(max_gpu_id)])}
+    else:
+        return {}
 
 
 class LogicalExchangeToPhysical(Rule):

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -1229,9 +1229,7 @@ def get_ray_env_dict():
     # Get the highest GPU id and expose all GPUs that have id lower than
     # the max id.
     max_gpu_id = max(Context().gpus) + 1
-    return {
-        "CUDA_VISIBLE_DEVICES": ",".join([str(n) for n in range(max_gpu_id)])
-    }
+    return {"CUDA_VISIBLE_DEVICES": ",".join([str(n) for n in range(max_gpu_id)])}
 
 
 class LogicalExchangeToPhysical(Rule):
@@ -1310,7 +1308,9 @@ class LogicalProjectToRayPhysical(Rule):
             parallelism = 2
 
             ray_process_env_dict = get_ray_env_dict()
-            ray_parallel_env_conf_dict = [ray_process_env_dict for _ in range(parallelism)]
+            ray_parallel_env_conf_dict = [
+                ray_process_env_dict for _ in range(parallelism)
+            ]
 
             exchange_plan = ExchangePlan(
                 inner_plan=project_plan,


### PR DESCRIPTION
This PR addresses two issues.

1. We previously only allows parallelism when there is more than two GPUs available. I think this is too conservative. First, some functional expressions only run on CPUs and even parallelization of CPU functional expression can bring performance benefit. Additionally, even if there is only one GPU available, it still provide performance benefit when parallelization is enabled because of better GPU utilizations. Currently, I just hardcode the DOP, but I am thinking to allow users to configure this themselves through the `eva.yml`. Any feedback on this? @xzdandy @gaurav274 @jarulraj 

2. I realize a bug related to the previous approach. This will happen for more than 1 GPU case. I will give a concrete example here. Let's assume we have two GPUs. The GPU id that we get from the `Context` for the second GPU is `1` because context runs in the main process, which detects two GPUs on the PyTorch side (e.g., `GPU ID = [0, 1]`. However, within the Ray process, after we set the environmental variable `CUDA_VISIBLE_DEVICES=1`, the PyTorch indices is reset. Because it only accesses one GPU within the Ray process, it only gets GPU ids like `GPU ID = [0]`. Thus, it causes the no GPU error when it moves to GPU `to('cuda:1')`. The fix is very easy, that we just simply expose all GPUs to every Ray process, so we don't need to worry about PyTorch device id reset. To expose all GPUs, we just find the max GPU id from the context and expose all GPU ids that are lower than the max in the environmental variables. 