### PR TITLE
feat: add chunk_size and chunk_overlap similar to langchain

### DIFF
--- a/evadb/binder/binder_utils.py
+++ b/evadb/binder/binder_utils.py
@@ -21,6 +21,7 @@ from evadb.catalog.catalog_type import TableType
 from evadb.catalog.catalog_utils import (
     get_video_table_column_definitions,
     is_document_table,
+    is_pdf_table,
     is_string_col,
     is_video_table,
 )
@@ -117,21 +118,22 @@ def check_groupby_pattern(table_ref: TableRef, groupby_string: str) -> None:
         err_msg = "Grouping by samples only supported for videos"
         raise BinderError(err_msg)
 
-    if suffix_string == "paragraphs" and not is_document_table(
-        table_ref.table.table_obj
-    ):
-        err_msg = "Grouping by paragraphs only supported for documents"
+    if suffix_string == "paragraphs" and not is_pdf_table(table_ref.table.table_obj):
+        err_msg = "Grouping by paragraphs only supported for pdf tables"
         raise BinderError(err_msg)
 
     # TODO ACTION condition on segment length?
 
 
 def check_table_object_is_groupable(table_ref: TableRef) -> None:
-    if not is_video_table(table_ref.table.table_obj) and not is_document_table(
-        table_ref.table.table_obj
+    table_obj = table_ref.table.table_obj
+
+    if not (
+        is_video_table(table_obj)
+        or is_document_table(table_obj)
+        or is_pdf_table(table_obj)
     ):
-        err_msg = "GROUP BY only supported for video and document tables"
-        raise BinderError(err_msg)
+        raise BinderError("GROUP BY only supported for video and document tables")
 
 
 def check_column_name_is_string(col_ref) -> None:

--- a/evadb/binder/statement_binder.py
+++ b/evadb/binder/statement_binder.py
@@ -28,7 +28,7 @@ from evadb.binder.binder_utils import (
 )
 from evadb.binder.statement_binder_context import StatementBinderContext
 from evadb.catalog.catalog_type import NdArrayType, TableType, VideoColumnName
-from evadb.catalog.catalog_utils import get_metadata_properties
+from evadb.catalog.catalog_utils import get_metadata_properties, is_document_table
 from evadb.configuration.constants import EvaDB_INSTALLATION_DIR
 from evadb.expression.abstract_expression import AbstractExpression, ExpressionType
 from evadb.expression.function_expression import FunctionExpression
@@ -133,10 +133,17 @@ class StatementBinder:
             self.bind(node.union_link)
             self._binder_context = current_context
 
+        # chunk_params only supported for DOCUMENT TYPE
+        if node.from_table.chunk_params:
+            assert is_document_table(
+                node.from_table.table.table_obj
+            ), "CHUNK related parameters only supported for DOCUMENT tables."
+
         assert not (
             self._binder_context.is_retrieve_audio()
             and self._binder_context.is_retrieve_video()
         ), "Cannot query over both audio and video streams"
+
         if self._binder_context.is_retrieve_audio():
             node.from_table.get_audio = True
         if self._binder_context.is_retrieve_video():

--- a/evadb/catalog/catalog_utils.py
+++ b/evadb/catalog/catalog_utils.py
@@ -56,10 +56,11 @@ def is_video_table(table: TableCatalogEntry):
 
 
 def is_document_table(table: TableCatalogEntry):
-    return (
-        table.table_type == TableType.DOCUMENT_DATA
-        or table.table_type == TableType.PDF_DATA
-    )
+    return table.table_type == TableType.DOCUMENT_DATA
+
+
+def is_pdf_table(table: TableCatalogEntry):
+    return table.table_type == TableType.PDF_DATA
 
 
 def is_string_col(col: ColumnCatalogEntry):

--- a/evadb/executor/storage_executor.py
+++ b/evadb/executor/storage_executor.py
@@ -45,7 +45,7 @@ class StorageExecutor(AbstractExecutor):
             elif self.node.table.table_type == TableType.IMAGE_DATA:
                 return storage_engine.read(self.node.table)
             elif self.node.table.table_type == TableType.DOCUMENT_DATA:
-                return storage_engine.read(self.node.table)
+                return storage_engine.read(self.node.table, self.node.chunk_params)
             elif self.node.table.table_type == TableType.STRUCTURED_DATA:
                 return storage_engine.read(self.node.table, self.node.batch_mem_size)
             elif self.node.table.table_type == TableType.PDF_DATA:

--- a/evadb/interfaces/relational/db.py
+++ b/evadb/interfaces/relational/db.py
@@ -134,20 +134,31 @@ class EvaDBCursor(object):
 
         return func_sync
 
-    def table(self, table_name: str) -> EvaDBQuery:
+    def table(
+        self, table_name: str, chunk_size: int = None, chunk_overlap: int = None
+    ) -> EvaDBQuery:
         """
         Retrieves data from a table in the database.
 
         Args:
-            table_name (str): Name of the table.
+            table_name (str): The name of the table to retrieve data from.
+            chunk_size (int, optional): The size of the chunk to break the document into. Only valid for DOCUMENT tables.
+                If not provided, the default value is 4000.
+            chunk_overlap (int, optional): The overlap between consecutive chunks. Only valid for DOCUMENT tables.
+                If not provided, the default value is 200.
 
         Returns:
-            EvaDBQuery: The EvaDBQuery object representing the table query.
+            EvaDBQuery: An EvaDBQuery object representing the table query.
 
         Examples:
             >>> relation = conn.table("sample_table")
+
+            Read a document table using chunk_size 100 and chunk_overlap 10.
+            >>> relation = conn.table("doc_table", chunk_size=100, chunk_overlap=10)
         """
-        table = parse_table_clause(table_name)
+        table = parse_table_clause(
+            table_name, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+        )
         # SELECT * FROM table
         select_stmt = SelectStatement(
             target_list=[TupleValueExpression(col_name="*")], from_table=table

--- a/evadb/optimizer/operators.py
+++ b/evadb/optimizer/operators.py
@@ -180,6 +180,7 @@ class LogicalGet(Operator):
         target_list: List[AbstractExpression] = None,
         sampling_rate: int = None,
         sampling_type: str = None,
+        chunk_params: dict = {},
         children=None,
     ):
         self._video = video
@@ -189,6 +190,7 @@ class LogicalGet(Operator):
         self._target_list = target_list
         self._sampling_rate = sampling_rate
         self._sampling_type = sampling_type
+        self.chunk_params = chunk_params
         super().__init__(OperatorType.LOGICALGET, children)
 
     @property
@@ -232,6 +234,7 @@ class LogicalGet(Operator):
             and self.target_list == other.target_list
             and self.sampling_rate == other.sampling_rate
             and self.sampling_type == other.sampling_type
+            and self.chunk_params == other.chunk_params
         )
 
     def __hash__(self) -> int:
@@ -245,6 +248,7 @@ class LogicalGet(Operator):
                 tuple(self.target_list or []),
                 self.sampling_rate,
                 self.sampling_type,
+                frozenset(self.chunk_params.items()),
             )
         )
 

--- a/evadb/optimizer/rules/rules.py
+++ b/evadb/optimizer/rules/rules.py
@@ -878,6 +878,7 @@ class LogicalGetToSeqScan(Rule):
                 predicate=before.predicate,
                 sampling_rate=before.sampling_rate,
                 sampling_type=before.sampling_type,
+                chunk_params=before.chunk_params,
             )
         )
         yield after

--- a/evadb/parser/evadb.lark
+++ b/evadb/parser/evadb.lark
@@ -110,9 +110,13 @@ sort_order: ASC | DESC
 // Forcing EXPLICIT JOIN KEYWORD
 table_sources: table_source
     
-table_source: table_source_item_with_sample join_part* 
-    
-table_source_item_with_sample: table_source_item alias_clause? (sample_clause | sample_clause_with_type)?
+table_source: table_source_item_with_param join_part* 
+
+table_source_item_with_param: table_source_item alias_clause? (sample_params | chunk_params)?
+
+sample_params:  sample_clause | sample_clause_with_type
+
+chunk_params: CHUNK_SIZE decimal_literal | CHUNK_SIZE decimal_literal CHUNK_OVERLAP decimal_literal | CHUNK_OVERLAP decimal_literal
 
 table_source_item: table_name | subquery_table_source_item   
     
@@ -128,7 +132,8 @@ sample_clause_with_type: SAMPLE sample_type decimal_literal*
 
 sample_type: IFRAMES | AUDIORATE
 
-join_part: JOIN table_source_item_with_sample (ON expression | USING LR_BRACKET uid_list RR_BRACKET)?  ->inner_join
+
+join_part: JOIN table_source_item_with_param (ON expression | USING LR_BRACKET uid_list RR_BRACKET)?  ->inner_join
          | JOIN LATERAL table_valued_function alias_clause? ->lateral_join
     
 alias_clause: AS? uid "(" uid_list ")" | AS? uid
@@ -307,6 +312,8 @@ AS:                                  "AS"i
 ASC:                                 "ASC"i
 BLOB:                                "BLOB"i
 BY:                                  "BY"i
+CHUNK_SIZE:                          "CHUNK_SIZE"i
+CHUNK_OVERLAP:                       "CHUNK_OVERLAP"i
 COLUMN:                              "COLUMN"i
 CREATE:                              "CREATE"i
 DATABASE:                            "DATABASE"i

--- a/evadb/parser/lark_visitor/_expressions.py
+++ b/evadb/parser/lark_visitor/_expressions.py
@@ -109,6 +109,16 @@ class Expressions:
                     expr_list.append(expression)
         return expr_list
 
+    def sample_params(self, tree):
+        sample_type = None
+        sample_freq = None
+        for child in tree.children:
+            if child.data == "sample_clause":
+                sample_freq = self.visit(child)
+            elif child.data == "sample_clause_with_type":
+                sample_type, sample_freq = self.visit(child)
+        return sample_type, sample_freq
+
     def sample_clause(self, tree):
         sample_list = self.visit_children(tree)
         assert len(sample_list) == 2
@@ -123,3 +133,24 @@ class Expressions:
             )
         else:
             return ConstantValueExpression(sample_list[1]), ConstantValueExpression(1)
+
+    def chunk_params(self, tree):
+        chunk_params = self.visit_children(tree)
+        assert len(chunk_params) == 2 or len(chunk_params) == 4
+        if len(chunk_params) == 4:
+            return {
+                "chunk_size": ConstantValueExpression(chunk_params[1]),
+                "chunk_overlap": ConstantValueExpression(chunk_params[3]),
+            }
+
+        elif len(chunk_params) == 2:
+            if chunk_params[0] == "CHUNK_SIZE":
+                return {
+                    "chunk_size": ConstantValueExpression(chunk_params[1]),
+                }
+            elif chunk_params[0] == "CHUNK_OVERLAP":
+                return {
+                    "chunk_overlap": ConstantValueExpression(chunk_params[1]),
+                }
+            else:
+                assert f"incorrect keyword found {chunk_params[0]}"

--- a/evadb/parser/lark_visitor/_table_sources.py
+++ b/evadb/parser/lark_visitor/_table_sources.py
@@ -47,7 +47,7 @@ class TableSources:
 
         for child in tree.children:
             if isinstance(child, Tree):
-                if child.data == "table_source_item_with_sample":
+                if child.data == "table_source_item_with_param":
                     left_node = self.visit(child)
                     join_nodes = [left_node]
                 elif child.data.endswith("join"):
@@ -67,25 +67,30 @@ class TableSources:
         else:
             return join_nodes[0]
 
-    def table_source_item_with_sample(self, tree):
+    def table_source_item_with_param(self, tree):
         sample_freq = None
         sample_type = None
         alias = None
         table = None
+        chunk_params = {}
 
         for child in tree.children:
             if isinstance(child, Tree):
                 if child.data == "table_source_item":
                     table = self.visit(child)
-                elif child.data == "sample_clause":
-                    sample_freq = self.visit(child)
-                elif child.data == "sample_clause_with_type":
+                elif child.data == "sample_params":
                     sample_type, sample_freq = self.visit(child)
+                elif child.data == "chunk_params":
+                    chunk_params = self.visit(child)
                 elif child.data == "alias_clause":
                     alias = self.visit(child)
 
         return TableRef(
-            table=table, alias=alias, sample_freq=sample_freq, sample_type=sample_type
+            table=table,
+            alias=alias,
+            sample_freq=sample_freq,
+            sample_type=sample_type,
+            chunk_params=chunk_params,
         )
 
     def table_source_item(self, tree):
@@ -160,7 +165,7 @@ class TableSources:
 
         for child in tree.children:
             if isinstance(child, Tree):
-                if child.data == "table_source_item_with_sample":
+                if child.data == "table_source_item_with_param":
                     table = self.visit(child)
                 elif child.data.endswith("expression"):
                     join_predicate = self.visit(child)

--- a/evadb/parser/utils.py
+++ b/evadb/parser/utils.py
@@ -34,8 +34,14 @@ def parse_predicate_expression(expr: str):
     return stmt.where_clause
 
 
-def parse_table_clause(expr: str):
-    mock_query = f"SELECT * FROM {expr};"
+def parse_table_clause(expr: str, chunk_size: int = None, chunk_overlap: int = None):
+    mock_query_parts = [f"SELECT * FROM {expr}"]
+    if chunk_size:
+        mock_query_parts.append(f"CHUNK_SIZE {chunk_size}")
+    if chunk_overlap:
+        mock_query_parts.append(f"CHUNK_OVERLAP {chunk_overlap}")
+    mock_query_parts.append(";")
+    mock_query = " ".join(mock_query_parts)
     stmt = Parser().parse(mock_query)[0]
     assert isinstance(stmt, SelectStatement), "Expected a select statement"
     assert stmt.from_table.is_table_atom

--- a/evadb/plan_nodes/storage_plan.py
+++ b/evadb/plan_nodes/storage_plan.py
@@ -49,6 +49,7 @@ class StoragePlan(AbstractPlan):
         sampling_rate: int = None,
         batch_mem_size: int = 30000000,
         sampling_type: str = None,
+        chunk_params: dict = {},
     ):
         super().__init__(PlanOprType.STORAGE_PLAN)
         self._table = table
@@ -62,6 +63,7 @@ class StoragePlan(AbstractPlan):
         self._predicate = predicate
         self._sampling_rate = sampling_rate
         self._sampling_type = sampling_type
+        self.chunk_params = chunk_params
 
     @property
     def table(self):
@@ -147,5 +149,6 @@ class StoragePlan(AbstractPlan):
                 self.predicate,
                 self.sampling_rate,
                 self.sampling_type,
+                frozenset(self.chunk_params.items()),
             )
         )

--- a/evadb/readers/document/document_reader.py
+++ b/evadb/readers/document/document_reader.py
@@ -16,20 +16,34 @@ from pathlib import Path
 from typing import Dict, Iterator
 
 from evadb.readers.abstract_reader import AbstractReader
-from evadb.readers.document.registry import _lazy_import_loader
+from evadb.readers.document.registry import (
+    _lazy_import_loader,
+    _lazy_import_text_splitter,
+)
 
 
 class DocumentReader(AbstractReader):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, chunk_params, **kwargs):
         super().__init__(*args, **kwargs)
         self._LOADER_MAPPING = _lazy_import_loader()
+        self._splitter_class = _lazy_import_text_splitter()
+
+        # https://github.com/hwchase17/langchain/blob/5b6bbf4ab2a33ed0d33ff5d3cb3979a7edc15682/langchain/text_splitter.py#L570
+        # by default we use chunk_size 4000 and overlap 200
+        self._chunk_size = chunk_params.get("chunk_size", 4000)
+        self._chunk_overlap = chunk_params.get("chunk_overlap", 200)
 
     def _read(self) -> Iterator[Dict]:
         ext = Path(self.file_url).suffix
         assert ext in self._LOADER_MAPPING, f"File Format {ext} not supported"
         loader_class, loader_args = self._LOADER_MAPPING[ext]
         loader = loader_class(self.file_url, **loader_args)
-        # load entire document as one entry
-        # https://github.com/hwchase17/langchain/blob/d4fd58963885465fba70a5cea9554a7b043b02a1/langchain/schema.py#L269
+
+        # todo: implement out own splitter
+        langchain_text_splitter = self._splitter_class(
+            chunk_size=self._chunk_size, chunk_overlap=self._chunk_overlap
+        )
+
         for data in loader.load():
-            yield {"data": data.page_content}
+            for row in langchain_text_splitter.split_documents([data]):
+                yield {"data": row.page_content}

--- a/evadb/readers/document/registry.py
+++ b/evadb/readers/document/registry.py
@@ -13,9 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import_err_msg = "`langchain` package not found, please run `pip install langchain`"
+SUPPORTED_TYPES = [
+    ".doc",
+    ".docx",
+    ".enex",
+    ".eml",
+    ".epub",
+    ".html",
+    ".md",
+    ".pdf",
+    ".ppt",
+    ".pptx",
+    ".txt",
+]
+
 
 def _lazy_import_loader():
-    import_err_msg = "`langchain` package not found, please run `pip install langchain`"
     try:
         from langchain.document_loaders import (
             EverNoteLoader,
@@ -48,16 +62,10 @@ def _lazy_import_loader():
     return LOADER_MAPPING
 
 
-SUPPORTED_TYPES = [
-    ".doc",
-    ".docx",
-    ".enex",
-    ".eml",
-    ".epub",
-    ".html",
-    ".md",
-    ".pdf",
-    ".ppt",
-    ".pptx",
-    ".txt",
-]
+def _lazy_import_text_splitter():
+    try:
+        from langchain.text_splitter import RecursiveCharacterTextSplitter
+    except ImportError:
+        raise ImportError(import_err_msg)
+
+    return RecursiveCharacterTextSplitter

--- a/evadb/storage/document_storage_engine.py
+++ b/evadb/storage/document_storage_engine.py
@@ -26,13 +26,15 @@ class DocumentStorageEngine(AbstractMediaStorageEngine):
     def __init__(self, db: EvaDBDatabase):
         super().__init__(db)
 
-    def read(self, table: TableCatalogEntry) -> Iterator[Batch]:
+    def read(self, table: TableCatalogEntry, chunk_params: dict) -> Iterator[Batch]:
         for doc_files in self._rdb_handler.read(self._get_metadata_table(table), 12):
             for _, (row_id, file_name) in doc_files.iterrows():
                 system_file_name = self._xform_file_url_to_file_name(file_name)
                 doc_file = Path(table.file_url) / system_file_name
                 # setting batch_mem_size = 1, we need fix it
-                reader = DocumentReader(str(doc_file), batch_mem_size=1)
+                reader = DocumentReader(
+                    str(doc_file), batch_mem_size=1, chunk_params=chunk_params
+                )
                 for batch in reader.read():
                     batch.frames[table.columns[0].name] = row_id
                     batch.frames[table.columns[1].name] = str(file_name)

--- a/test/binder/test_statement_binder.py
+++ b/test/binder/test_statement_binder.py
@@ -236,6 +236,7 @@ class StatementBinderTests(unittest.TestCase):
             select_statement.orderby_list = [(mocks[2], 0), (mocks[3], 0)]
             select_statement.groupby_clause = mocks[4]
             select_statement.groupby_clause.value = "8 frames"
+            select_statement.from_table.chunk_params = None
             binder._bind_select_statement(select_statement)
             mock_binder.assert_any_call(select_statement.from_table)
             mock_binder.assert_any_call(select_statement.where_clause)
@@ -252,11 +253,13 @@ class StatementBinderTests(unittest.TestCase):
             select_statement = MagicMock()
             select_statement.union_link = None
             select_statement.groupby_clause = None
+            select_statement.from_table.chunk_params = None
             binder._bind_select_statement(select_statement)
             self.assertEqual(mock_ctx.call_count, 0)
 
             binder = StatementBinder(StatementBinderContext(MagicMock()))
             select_statement = MagicMock()
+            select_statement.from_table.chunk_params = None
             select_statement.groupby_clause = None
             binder._bind_select_statement(select_statement)
             self.assertEqual(mock_ctx.call_count, 1)

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -520,7 +520,7 @@ class LoadExecutorTest(unittest.TestCase):
         )
         result = execute_query_fetch_all(self.evadb, "SELECT * from pdfs;")
         self.assertEqual(len(result.columns), 3)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 26)
 
 
 if __name__ == "__main__":

--- a/test/integration_tests/test_select_executor.py
+++ b/test/integration_tests/test_select_executor.py
@@ -766,3 +766,16 @@ class SelectExecutorTest(unittest.TestCase):
 
         batch = execute_query_fetch_all(self.evadb, "SELECT * FROM table1;")
         self.assertTrue("table1._row_id" in batch.columns)
+
+    def test_chunk_param_should_fail(self):
+        with self.assertRaises(AssertionError):
+            execute_query_fetch_all(
+                self.evadb,
+                "SELECT data from MyVideo chunk_size 4000 chunk_overlap 200;",
+            )
+
+        with self.assertRaises(AssertionError):
+            execute_query_fetch_all(
+                self.evadb,
+                "SELECT data from MemeImages chunk_size 4000 chunk_overlap 200;",
+            )

--- a/test/optimizer/test_statement_to_opr_converter.py
+++ b/test/optimizer/test_statement_to_opr_converter.py
@@ -338,4 +338,4 @@ statement_to_opr_converter.metadata_definition_to_udf_metadata"
         for derived_operator in derived_operators:
             sig = signature(derived_operator.__init__)
             params = sig.parameters
-            self.assertLess(len(params), 10)
+            self.assertLess(len(params), 15)

--- a/test/util.py
+++ b/test/util.py
@@ -189,6 +189,21 @@ def get_mock_object(class_type, number_of_args):
             MagicMock(),
             MagicMock(),
         )
+    elif number_of_args == 13:
+        return class_type(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
     else:
         raise Exception("Too many args")
 


### PR DESCRIPTION
Added support for `chunk_size` and `chunk_overlap` for `document` tables. By default, the values are set to chunk_size=4000, chunk_overlap=200. 

```
SELECT data from docs chunk_size 2000 chunk_overlap 50;
or
cursor.table("docs", chunk_size=2000, chunk_overlap=50).select("data").df()
```