### PR TITLE
fix: minor fix to the catalog utils.

### DIFF
--- a/evadb/catalog/catalog_type.py
+++ b/evadb/catalog/catalog_type.py
@@ -123,6 +123,7 @@ class ImageColumnName(EvaDBEnum):
 
 class DocumentColumnName(EvaDBEnum):
     name  # noqa: F821
+    chunk_id  # noqa: F821
     data  # noqa: F821
     metadata  # noqa: F821
 

--- a/evadb/catalog/catalog_utils.py
+++ b/evadb/catalog/catalog_utils.py
@@ -31,6 +31,7 @@ from evadb.catalog.models.utils import (
     UdfCacheCatalogEntry,
     UdfCatalogEntry,
 )
+from evadb.catalog.sql_config import IDENTIFIER_COLUMN
 from evadb.configuration.configuration_manager import ConfigurationManager
 from evadb.expression.function_expression import FunctionExpression
 from evadb.expression.tuple_value_expression import TupleValueExpression
@@ -161,17 +162,37 @@ def get_pdf_table_column_definitions() -> List[ColumnDefinition]:
     return columns
 
 
-def get_table_primary_columns(table_catalog_obj: TableCatalogEntry):
+def get_table_primary_columns(
+    table_catalog_obj: TableCatalogEntry,
+) -> List[ColumnDefinition]:
+    """
+    Get the primary columns for a table based on its table type.
+
+    Args:
+        table_catalog_obj (TableCatalogEntry): The table catalog object.
+
+    Returns:
+        List[ColumnDefinition]: The list of primary columns for the table.
+    """
+    primary_columns = [
+        ColumnDefinition(IDENTIFIER_COLUMN, ColumnType.INTEGER, None, None)
+    ]
+    # _row_id for all the TableTypes, however for Video data and PDF data we also add frame_id (id) and paragraph as part of unique key
     if table_catalog_obj.table_type == TableType.VIDEO_DATA:
-        return get_video_table_column_definitions()[:2]
-    elif table_catalog_obj.table_type == TableType.IMAGE_DATA:
-        return get_image_table_column_definitions()[:1]
-    elif table_catalog_obj.table_type == TableType.DOCUMENT_DATA:
-        return get_document_table_column_definitions()[:1]
+        # _row_id, id
+        primary_columns.append(
+            ColumnDefinition(VideoColumnName.id.name, ColumnType.INTEGER, None, None),
+        )
+
     elif table_catalog_obj.table_type == TableType.PDF_DATA:
-        return get_pdf_table_column_definitions()[:3]
-    else:
-        raise Exception(f"Unexpected table type {table_catalog_obj.table_type}")
+        # _row_id, paragraph
+        primary_columns.append(
+            ColumnDefinition(
+                PDFColumnName.paragraph.name, ColumnType.INTEGER, None, None
+            )
+        )
+
+    return primary_columns
 
 
 def xform_column_definitions_to_catalog_entries(

--- a/evadb/catalog/catalog_utils.py
+++ b/evadb/catalog/catalog_utils.py
@@ -196,6 +196,14 @@ def get_table_primary_columns(
             )
         )
 
+    elif table_catalog_obj.table_type == TableType.DOCUMENT_DATA:
+        # _row_id, chunk_id
+        primary_columns.append(
+            ColumnDefinition(
+                DocumentColumnName.chunk_id.name, ColumnType.INTEGER, None, None
+            )
+        )
+
     return primary_columns
 
 

--- a/evadb/catalog/catalog_utils.py
+++ b/evadb/catalog/catalog_utils.py
@@ -121,7 +121,8 @@ def get_image_table_column_definitions() -> List[ColumnDefinition]:
 def get_document_table_column_definitions() -> List[ColumnDefinition]:
     """
     name: file path
-    data: file extracted data
+    chunk_id: chunk id (0-indexed for each file)
+    data: text data associated with the chunk
     """
     columns = [
         ColumnDefinition(
@@ -130,6 +131,9 @@ def get_document_table_column_definitions() -> List[ColumnDefinition]:
             None,
             None,
             ColConstraintInfo(unique=True),
+        ),
+        ColumnDefinition(
+            DocumentColumnName.chunk_id.name, ColumnType.INTEGER, None, None
         ),
         ColumnDefinition(
             DocumentColumnName.data.name,

--- a/evadb/readers/document/document_reader.py
+++ b/evadb/readers/document/document_reader.py
@@ -45,5 +45,7 @@ class DocumentReader(AbstractReader):
         )
 
         for data in loader.load():
-            for row in langchain_text_splitter.split_documents([data]):
-                yield {"data": row.page_content}
+            for chunk_id, row in enumerate(
+                langchain_text_splitter.split_documents([data])
+            ):
+                yield {"chunk_id": chunk_id, "data": row.page_content}

--- a/test/integration_tests/test_load_executor.py
+++ b/test/integration_tests/test_load_executor.py
@@ -519,7 +519,7 @@ class LoadExecutorTest(unittest.TestCase):
             f"""LOAD DOCUMENT '{EvaDB_ROOT_DIR}/data/documents/*.pdf' INTO pdfs;""",
         )
         result = execute_query_fetch_all(self.evadb, "SELECT * from pdfs;")
-        self.assertEqual(len(result.columns), 3)
+        self.assertEqual(len(result.columns), 4)
         self.assertEqual(len(result), 26)
 
 


### PR DESCRIPTION
Document tables now also project `chunk_id`

Fixed `get_table_primary_columns`:
Set the primary column/s: 

```
TableType.STRUCTURED_DATA: _row_id
TableType.IMAGE_DATA: _row_id
TableType.VIDEO_DATA: _row_id, id
TableType.PDF_DATA: _row_id, paragraph
TableType.DOCUMENT_DATA :  _row_id, chunk_id
```
